### PR TITLE
Add explicit light theme and toggle logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,23 @@
       color-scheme: dark;
     }
 
+    .light{
+      --ink:#0b0f1a;
+      --muted:#6b7280;
+      --als-blue:#0b67c2;
+      --als-blue-strong:#0a5cb0;
+      --thead:#0b67c2;
+      --thead-text:#ffffff;
+      --grid:#e6e9ef;
+      --zebra:#ffffff;
+      --chip-cat-tx:#0b67c2;
+      --chip-cat-br:#0b67c2;
+      --done-tx:#059669;
+      --open-tx:#0b67c2;
+      --paper:#ffffff;
+      color-scheme: light;
+    }
+
     html,body{height:100%}
     body{
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
@@ -302,22 +319,25 @@
       renderRows(rows);
     });
 
-    const themeBtn = document.getElementById('themeBtn');
+      const themeBtn = document.getElementById('themeBtn');
 
-    function applyTheme(isDark){
-      document.body.classList.toggle('dark', isDark);
-      themeBtn.textContent = isDark ? 'Light mode' : 'Dark mode';
-    }
+      function applyTheme(theme){
+        const isDark = theme === 'dark';
+        document.body.classList.toggle('dark', isDark);
+        document.body.classList.toggle('light', !isDark);
+        themeBtn.textContent = isDark ? 'Light mode' : 'Dark mode';
+      }
 
-    const savedTheme = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    applyTheme(savedTheme ? savedTheme === 'dark' : prefersDark);
+      const savedTheme = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme = savedTheme || (prefersDark ? 'dark' : 'light');
+      applyTheme(theme);
 
-    themeBtn.addEventListener('click', ()=>{
-      const isDark = !document.body.classList.contains('dark');
-      applyTheme(isDark);
-      localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    });
+      themeBtn.addEventListener('click', ()=>{
+        const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+        applyTheme(newTheme);
+        localStorage.setItem('theme', newTheme);
+      });
 
     const demo = [
       {


### PR DESCRIPTION
## Summary
- add explicit `.light` CSS variables and `color-scheme: light`
- toggle `.light`/`.dark` classes in `applyTheme` and initialize from saved or preferred scheme
- update button text based on active theme

## Testing
- `node` script to simulate theme toggle and verify classes/button text
- `npm test` *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68c6abb0353c832690adc092878b6839