### PR TITLE
feat: add sortable headers accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,9 @@
       font-weight:800; font-size:11px; padding:10px 8px; border-right:1px solid rgba(255,255,255,.08);
       cursor:pointer;
     }
+    thead th .sort-arrow{ margin-left:4px; }
+    thead th[data-sort="asc"] .sort-arrow::after{ content:'\25B2'; }
+    thead th[data-sort="desc"] .sort-arrow::after{ content:'\25BC'; }
     thead th:first-child{ border-top-left-radius:3px; }
     thead th:last-child{ border-top-right-radius:3px; border-right:none; }
 
@@ -160,17 +163,17 @@
     <table role="table" aria-label="Work Orders" id="workTable">
       <thead>
         <tr>
-          <th class="col-id" data-col="id">ID</th>
-          <th class="col-title" data-col="title">Title</th>
-          <th class="col-status" data-col="status">Status</th>
-          <th class="col-priority" data-col="priority">Priority</th>
-          <th class="col-createdby" data-col="createdBy">Created by</th>
-          <th class="col-createdon" data-col="createdOn">Created on</th>
-          <th class="col-completedon" data-col="completedOn">Completed on</th>
-          <th class="col-updated" data-col="updated">Last updated</th>
-          <th class="col-location" data-col="location">Location</th>
-          <th class="col-asset" data-col="asset">Asset</th>
-          <th class="col-categories" data-col="categories">Categories</th>
+          <th class="col-id" data-col="id" tabindex="0"><span>ID</span><span class="sort-arrow"></span></th>
+          <th class="col-title" data-col="title" tabindex="0"><span>Title</span><span class="sort-arrow"></span></th>
+          <th class="col-status" data-col="status" tabindex="0"><span>Status</span><span class="sort-arrow"></span></th>
+          <th class="col-priority" data-col="priority" tabindex="0"><span>Priority</span><span class="sort-arrow"></span></th>
+          <th class="col-createdby" data-col="createdBy" tabindex="0"><span>Created by</span><span class="sort-arrow"></span></th>
+          <th class="col-createdon" data-col="createdOn" tabindex="0"><span>Created on</span><span class="sort-arrow"></span></th>
+          <th class="col-completedon" data-col="completedOn" tabindex="0"><span>Completed on</span><span class="sort-arrow"></span></th>
+          <th class="col-updated" data-col="updated" tabindex="0"><span>Last updated</span><span class="sort-arrow"></span></th>
+          <th class="col-location" data-col="location" tabindex="0"><span>Location</span><span class="sort-arrow"></span></th>
+          <th class="col-asset" data-col="asset" tabindex="0"><span>Asset</span><span class="sort-arrow"></span></th>
+          <th class="col-categories" data-col="categories" tabindex="0"><span>Categories</span><span class="sort-arrow"></span></th>
         </tr>
       </thead>
       <tbody id="tbody"></tbody>
@@ -257,9 +260,17 @@
       }).join('\n');
     }
 
-    function sortByColumn(col){
+    function sortByColumn(col, th){
       const direction = sortState[col] === 'asc' ? 'desc' : 'asc';
-      sortState[col] = direction;
+      sortState = { [col]: direction };
+      document.querySelectorAll('thead th[data-col]').forEach(h=>{
+        if(h!==th){
+          h.removeAttribute('data-sort');
+          h.setAttribute('aria-sort','none');
+        }
+      });
+      th.setAttribute('data-sort', direction);
+      th.setAttribute('aria-sort', direction==='asc'?'ascending':'descending');
       const sorted = [...currentRows].sort((a,b)=>{
         const va = (pick(a, MAP[col])||'').toString().toLowerCase();
         const vb = (pick(b, MAP[col])||'').toString().toLowerCase();
@@ -271,7 +282,13 @@
     }
 
     document.querySelectorAll('thead th[data-col]').forEach(th=>{
-      th.addEventListener('click', ()=>sortByColumn(th.dataset.col));
+      th.addEventListener('click', ()=>sortByColumn(th.dataset.col, th));
+      th.addEventListener('keydown', e=>{
+        if(e.key==='Enter' || e.key===' '){
+          e.preventDefault();
+          sortByColumn(th.dataset.col, th);
+        }
+      });
     });
 
     function parseDelimited(text){


### PR DESCRIPTION
## Summary
- add keyboard focusable column headers with sort arrows
- show arrow direction with new `data-sort` and aria attributes
- allow Enter/Space to trigger column sorting

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6adac60848326b2d0e9c53a1f8b6c