### PR TITLE
feat: color-coded status badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
       --chip-cat-br:#0b67c2;
       --done-tx:#059669;
       --open-tx:#0b67c2;
+      --hold-tx:#b45309;
+      --done-bg:#0596691a;
+      --open-bg:#0b67c21a;
+      --hold-bg:#f59e0b1a;
       --paper:#ffffff;
     }
 
@@ -36,6 +40,10 @@
         --chip-cat-br:#3b82f6;
         --done-tx:#10b981;
         --open-tx:#3b82f6;
+        --hold-tx:#fbbf24;
+        --done-bg:#10b98133;
+        --open-bg:#3b82f633;
+        --hold-bg:#f59e0b33;
         --paper:#111827;
       }
     }
@@ -53,6 +61,10 @@
       --chip-cat-br:#3b82f6;
       --done-tx:#10b981;
       --open-tx:#3b82f6;
+      --hold-tx:#fbbf24;
+      --done-bg:#10b98133;
+      --open-bg:#3b82f633;
+      --hold-bg:#f59e0b33;
       --paper:#111827;
       color-scheme: dark;
     }
@@ -70,6 +82,10 @@
       --chip-cat-br:#0b67c2;
       --done-tx:#059669;
       --open-tx:#0b67c2;
+      --hold-tx:#b45309;
+      --done-bg:#0596691a;
+      --open-bg:#0b67c21a;
+      --hold-bg:#f59e0b1a;
       --paper:#ffffff;
       color-scheme: light;
     }
@@ -130,6 +146,17 @@
     .dark .chip-cat.electrical{background:#10b98133; color:#6ee7b7; border-color:#10b981;}
     .dark .chip-cat.resin{background:#a855f733; color:#d8b4fe; border-color:#a855f7;}
     .dark .chip-cat.weekly-procedures{background:#ef444433; color:#fca5a5; border-color:#ef4444;}
+
+    .status-chip{ display:inline-flex; align-items:center; padding:2px 8px; border-radius:6px; font-weight:700; }
+    .status-chip::before{ margin-right:4px; }
+    .status-chip.done{ color:var(--done-tx); background:var(--done-bg); }
+    .status-chip.done::before{ content:'\2713'; }
+    .status-chip.open{ color:var(--open-tx); background:var(--open-bg); }
+    .status-chip.open::before{ content:'\26AA'; }
+    .status-chip.in-progress{ color:var(--open-tx); background:var(--open-bg); }
+    .status-chip.in-progress::before{ content:'\23F3'; }
+    .status-chip.on-hold{ color:var(--hold-tx); background:var(--hold-bg); }
+    .status-chip.on-hold::before{ content:'\23F8'; }
 
     .ico{ width:16px; height:16px; vertical-align:-3px; margin-right:6px; }
     .done{ color:var(--done-tx); font-weight:800; }
@@ -233,6 +260,10 @@
               return `<span class="${cls}">${esc(cat)}</span>`;
             }).join('');
             return `<td>${chips}</td>`;
+          }
+          if(h === 'Status'){
+            const slug = slugify(String(v||''));
+            return `<td><span class="status-chip ${slug}">${esc(v)}</span></td>`;
           }
           return `<td>${esc(v)}</td>`;
         }).join('')}</tr>`;


### PR DESCRIPTION
## Summary
- add theme variables and styling for status chips
- render colored status badges when displaying rows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6baf548948326be5b301752f7239b