### PR TITLE
Improve table header accessibility and theme toggle semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,18 @@
     .controls textarea{ width:420px; height:100px; padding:8px; border:1px solid var(--grid); border-radius:6px; }
     .btn{ padding:6px 10px; border:1px solid var(--als-blue); border-radius:8px; background:var(--paper); color:var(--als-blue); font-weight:700; cursor:pointer; }
 
+    .visually-hidden{
+      position:absolute;
+      width:1px;
+      height:1px;
+      padding:0;
+      margin:-1px;
+      overflow:hidden;
+      clip:rect(0,0,0,0);
+      white-space:nowrap;
+      border:0;
+    }
+
     @media print{
       @page{ size: A4 landscape; margin: 10mm; }
       body{ font-size:11px; }
@@ -246,7 +258,7 @@
 
     function renderHeader(headers){
       currentHeaders = headers;
-      elThead.innerHTML = `<tr>${headers.map(h=>`<th data-col="${esc(h)}" tabindex="0"><span>${esc(h)}</span><span class="sort-arrow"></span></th>`).join('')}</tr>`;
+      elThead.innerHTML = `<tr>${headers.map(h=>`<th scope="col" data-col="${esc(h)}" tabindex="0" aria-sort="none"><span class="header-text">${esc(h)}</span><span class="visually-hidden sort-instructions">Activate to sort ascending by ${esc(h)}</span><span aria-hidden="true" class="sort-arrow"></span></th>`).join('')}</tr>`;
       elThead.querySelectorAll('th').forEach(th=>{
         th.addEventListener('click', ()=>sortByColumn(th.getAttribute('data-col'), th));
         th.addEventListener('keydown', e=>{
@@ -292,10 +304,22 @@
         if(h!==th){
           h.removeAttribute('data-sort');
           h.setAttribute('aria-sort','none');
+          const instruction = h.querySelector('.sort-instructions');
+          if(instruction){
+            const colName = h.getAttribute('data-col');
+            instruction.textContent = `Activate to sort ascending by ${colName}`;
+          }
         }
       });
       th.setAttribute('data-sort', direction);
       th.setAttribute('aria-sort', direction==='asc'?'ascending':'descending');
+      const thInstruction = th.querySelector('.sort-instructions');
+      if(thInstruction){
+        const colName = th.getAttribute('data-col');
+        thInstruction.textContent = direction==='asc'
+          ? `Sorted ascending. Activate to sort descending by ${colName}`
+          : `Sorted descending. Activate to sort ascending by ${colName}`;
+      }
       const sorted = [...currentRows].sort((a,b)=>{
         const va = a[col] ?? '';
         const vb = b[col] ?? '';
@@ -370,6 +394,8 @@
         document.body.classList.toggle('dark', isDark);
         document.body.classList.toggle('light', !isDark);
         themeBtn.textContent = isDark ? 'Light mode' : 'Dark mode';
+        themeBtn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+        themeBtn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
       }
 
       const savedTheme = localStorage.getItem('theme');


### PR DESCRIPTION
## Summary
- add `scope="col"` and supporting visible/hidden text to header cells for accessible sorting
- refresh sort instructions dynamically so screen readers announce the current state
- extend the theme toggle to manage `aria-pressed`, provide an action label, and include a visually hidden utility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec74bc7808326bc878d234e9441c8