### PR TITLE
Normalize parsed headers for BOM-prefixed CSVs

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,9 +334,15 @@ tbody td{ overflow-wrap:anywhere; }
 
   function parseDelimited(text){
     const sep = text.includes('\t') ? '\t' : ',';
-    const rows = text.trim().split(/\r?\n/).map(r=>r.split(new RegExp(`${sep}(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)`)).map(c=>c.replace(/^\"|\"$/g,'')));
-    const headers = rows.shift() || [];
-    const data = rows.map(r=>Object.fromEntries(r.map((v,i)=>[headers[i]||`col${i}`, v])));
+    const rows = text.trim().split(/\r?\n/).map(r =>
+      r.split(new RegExp(`${sep}(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)`)).map(c => c.replace(/^\"|\"$/g,''))
+    );
+    const rawHeaders = rows.shift() || [];
+    const headers = rawHeaders.map((h, i) => {
+      const cleaned = String(h == null ? '' : h).replace(/^\uFEFF/, '').trim();
+      return cleaned || `col${i}`;
+    });
+    const data = rows.map(r => Object.fromEntries(r.map((v, i) => [headers[i] || `col${i}`, v])));
     return {headers, rows:data};
   }
 


### PR DESCRIPTION
## Summary
- trim and strip any leading BOM characters from parsed header names
- reuse the normalized header keys when building row objects so downstream consumers receive cleaned field names

## Testing
- `node - <<'NODE'
function parseDelimited(text){
  const sep = text.includes('\t') ? '\t' : ',';
  const rows = text.trim().split(/\r?\n/).map(r =>
    r.split(new RegExp(`${sep}(?=(?:[^\\"]*\\"[^\\"]*\\")*[^\\"]*$)`)).map(c => c.replace(/^\\"|\\"$/g,''))
  );
  const rawHeaders = rows.shift() || [];
  const headers = rawHeaders.map((h, i) => {
    const cleaned = String(h == null ? '' : h).replace(/^\\uFEFF/, '').trim();
    return cleaned || `col${i}`;
  });
  const data = rows.map(r => Object.fromEntries(r.map((v, i) => [headers[i] || `col${i}`, v])));
  return {headers, rows:data};
}
const sample = '\\ufeffID, Title\\n123,Example';
console.log(parseDelimited(sample));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68ced50c8064832690156709a9e48c8e