### PR TITLE
Remove dashboard footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,6 @@
     .done{ color:var(--done-tx); font-weight:800; }
     .open{ color:var(--open-tx); font-weight:800; }
 
-    footer{ margin-top:8px; color:var(--muted); font-size:11px; display:flex; justify-content:space-between; }
 
     .controls{ display:flex; gap:12px; align-items:center; margin:8px 0 12px; font-size:12px; flex-wrap:wrap; }
     .controls input[type="file"], .controls textarea{ font:inherit; }
@@ -314,11 +313,6 @@ tbody td{ overflow-wrap:anywhere; }
     <section id="dash-mm"    class="dash" data-active="false" role="tabpanel" aria-labelledby="tab-mm"></section>
     <section id="dash-keith" class="dash" data-active="false" role="tabpanel" aria-labelledby="tab-keith"></section>
     <section id="dash-by"    class="dash" data-active="false" role="tabpanel" aria-labelledby="tab-by"></section>
-
-    <footer>
-      <span></span>
-      <span></span>
-    </footer>
   </div>
 
 <script>


### PR DESCRIPTION
## Summary
- remove the footer styles and markup from the dashboard page now that the timestamp is no longer needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceefc44f54832698dfcb41e8e6c358