### PR TITLE
Adjust table wrapping for status chips and verbose columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,16 @@
     }
 
     table{ width:100%; min-width:900px; border-collapse:separate; border-spacing:0; }
-    table th, table td{ overflow-wrap:anywhere; word-break:break-word; }
+    table th, table td{ overflow-wrap:normal; word-break:normal; }
+    tbody td:nth-child(2),
+    tbody td:nth-child(5),
+    tbody td:nth-child(6),
+    tbody td:nth-child(10),
+    tbody td:nth-child(11),
+    tbody td:nth-child(12){
+      overflow-wrap:anywhere;
+      word-break:break-word;
+    }
     thead th { position: sticky; top: var(--sticky-controls-offset); z-index: 3; }
     thead th{
       background:var(--thead); color:var(--thead-text); text-transform:uppercase; letter-spacing:.6px;
@@ -170,7 +179,7 @@
       white-space:nowrap;
     }
 
-    .status-chip{ display:inline-flex; align-items:center; padding:2px 8px; border-radius:6px; font-weight:700; }
+    .status-chip{ display:inline-flex; align-items:center; padding:2px 8px; border-radius:6px; font-weight:700; white-space:nowrap; }
     .status-chip::before{ margin-right:4px; }
     .status-chip.done{ color:var(--done-tx); background:var(--done-bg); }
     .status-chip.done::before{ content:'\2713'; }


### PR DESCRIPTION
## Summary
- reset default table cell wrapping to prevent chips from breaking across lines
- apply wrap rules only to verbose columns so long text still flows within column widths
- enforce no-wrap on status chips to keep badges intact in narrow viewports

## Testing
- python3 -m http.server 8000 (manual verification via mobile viewport screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68cf08042ed48326a3b022c23c865c33