### PR TITLE
Skip dashboard rendering when target is missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -920,6 +920,12 @@ function ingestToDashboards(headers, rows){
 
   [['dash-all','all'],['dash-ek','ek'],['dash-mm','mm'],['dash-keith','keith'],['dash-by','by']].forEach(([id,key])=>{
     const el=document.getElementById(id);
+    if(!el){
+      if(typeof console!=='undefined' && typeof console.warn==='function'){
+        console.warn(`Skipping dashboard "${id}" – element not found.`);
+      }
+      return;
+    }
     renderDashboard(el, safeHeaders, groups[key]);
   });
 


### PR DESCRIPTION
## Summary
- guard ingestToDashboards against missing dashboard containers before rendering
- log a warning when a dashboard section is absent instead of calling renderDashboard with null

## Testing
- manual verification via Playwright to load the full dashboard and a variant missing dash-by to ensure no errors


------
https://chatgpt.com/codex/tasks/task_e_68cf24c78384832695724cb9b8275f5c