### PR TITLE
Adjust table scroll container behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,9 +117,18 @@
 
     .top-rule{ height:6px; background:var(--als-blue); border-bottom:1px solid var(--als-blue-strong); margin:8px 0 10px; }
 
+.table-scroll{
+  height: calc(100vh - var(--sticky-controls-offset) - 24px);
+  overflow:auto;
+  border:1px solid var(--grid);
+  border-radius:12px;
+}
+
 .table-scroll thead{
   position: sticky;
-  top: var(--sticky-controls-offset);
+  top: 0;
+  z-index:112;
+  background:var(--thead);
 }
 
 /* Header cell visuals (no sticky here) */
@@ -263,7 +272,6 @@ table th, table td{
 }
 
 /* keep these */
-.table-scroll thead{ position: sticky; top: var(--sticky-controls-offset); z-index:112; }
 .sticky-top{ z-index:120; }
 
 /* optional: keep vertical scrollbar width constant on all pages */


### PR DESCRIPTION
## Summary
- give each dashboard table wrapper its own scroll area with viewport-based height
- adjust sticky header offset to stick to the table scroll container and keep header background applied

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf3150bed88326ad3c25644cb991a2