### PR TITLE
Optimize filter change handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1081,6 +1081,7 @@ function getAgeLabel(row){
 // --- State cache for rendering ---
 let LAST_HEADERS = null;
 let ALL_ROWS = null;
+let __LAST_FILTERS_JSON = null;
 
 const $exportCsvBtn = document.getElementById('exportCsvBtn');
 
@@ -2654,16 +2655,28 @@ window.addEventListener('resize', ()=>{
 
 // Re-render on filter change
 function handleFilterChange(){
+  const filters = getFilters();
+  const nextJson = JSON.stringify(filters);
+  const same = __LAST_FILTERS_JSON === nextJson;
+
+  if (same){
+    if (!LAST_HEADERS || !ALL_ROWS){
+      updateChipsFromFilters(filters);   // <- mapped to `search`
+    }
+    return;
+  }
+
+  __LAST_FILTERS_JSON = nextJson;
+
   if (LAST_HEADERS && ALL_ROWS){
     ingestToDashboards(LAST_HEADERS, ALL_ROWS);
   } else {
-    const f = getFilters();
-    updateChipsFromFilters(f);   // <- mapped to `search`
+    updateChipsFromFilters(filters);   // <- mapped to `search`
   }
 }
 $statusFilter?.addEventListener('change', handleFilterChange);
 $priorityFilter?.addEventListener('change', handleFilterChange);
-$searchInput?.addEventListener('input', debounce(handleFilterChange, 160));
+$searchInput?.addEventListener('input', debounce(handleFilterChange, 300));
 $searchInput?.addEventListener('change', handleFilterChange);
 
 /* Legend popover JS */


### PR DESCRIPTION
## Summary
- add a module-level cache of the current filters to skip redundant dashboard ingestion
- refresh filter chips when data is still loading and leave dashboards untouched if filters are unchanged
- slow the search input debounce interval to roughly 300ms to reduce refresh churn

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9379e3a2c832682842da471043c6c