### PR TITLE
Cache haystack strings for search filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -2022,7 +2022,15 @@ function getFilters(){
   };
 }
 
-const SEARCHABLE_FIELDS = ['ID','Title','Status','Priority','Assigned to','Created by','Created on','Completed on','Last updated','Location','Asset','Categories','Age'];
+const SEARCH_KEYS = ['ID','Title','Status','Priority','Assigned to','Created by','Created on','Completed on','Last updated','Location','Asset','Categories','Age'];
+
+function buildHaystack(row){
+  if(!row) return '';
+  return SEARCH_KEYS
+    .map(key => String(row[key] ?? ''))
+    .join(' ')
+    .toLowerCase();
+}
 
 function applyFilters(rows){
   const filters = getFilters();
@@ -2040,8 +2048,8 @@ function applyFilters(rows){
 
     let okSearch = true;
     if(tokens.length){
-      const haystack = SEARCHABLE_FIELDS.map(key => String(r[key] ?? '')).join(' ').toLowerCase();
-      okSearch = tokens.every(t => haystack.includes(t));
+      const hay = r.__haystack || '';
+      okSearch = tokens.every(t => hay.includes(t));
     }
 
     return okStatus && okPrio && okSearch;
@@ -2427,6 +2435,7 @@ function ingestToDashboards(headers, rows){
     o.__ageMs      = ms;                // raw milliseconds
     o.Age          = fmtAge(ms);        // human label like "12d 3h"
     o.__ageBucket  = ageBucket(ms);     // fresh | stale | old | ancient
+    o.__haystack   = buildHaystack(o);  // cached lower-case search text
     return o;
   });
 


### PR DESCRIPTION
## Summary
- precompute a lower-cased haystack string for each row during ingestion
- reuse the cached haystack string when applying search token filters

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9379bdc9c83269350cf0800fc72f9