### PR TITLE
Ensure updateTheadHeight targets the visible dashboard table

### DIFF
--- a/index.html
+++ b/index.html
@@ -2606,7 +2606,10 @@ function sortScoped(th, container){
 }
   
 function updateTheadHeight(){
-  const activeDash = document.querySelector('.dash[data-active="true"]:not([hidden])');
+  const activeDash =
+    document.querySelector('.dash-table[data-active="true"]:not([hidden])') ||
+    Array.from(document.querySelectorAll('.dash-table'))
+      .find(el => el.offsetParent !== null && !el.hidden);
   const tableWrap = activeDash?.querySelector('.table-scroll');
   let h = 0;
   if(tableWrap && tableWrap.offsetParent !== null && !tableWrap.hidden){


### PR DESCRIPTION
## Summary
- update the sticky header height calculation to prefer the active dashboard table
- fall back to the first visible dashboard table if none are flagged active

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e01accea9483268a1ea45eaee284a9