### PR TITLE
Fix sticky table header positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
       --paper:#ffffff;
       --priority-rail:#E85A70;
       --sticky-controls-offset:0px;
+      --thead-natural-top:0px;
+      --thead-gap:0px;
     }
 
     @media (prefers-color-scheme: dark){
@@ -573,7 +575,7 @@ body::before{
 /* Real sticky header cells */
 .table-scroll thead th{
   position: sticky;
-  top: var(--ui-offset, var(--sticky-controls-offset, 0px));
+  top: calc(var(--ui-offset, var(--sticky-controls-offset, 0px)) - var(--thead-natural-top, 0px));
   background: transparent(--thead);
   color: var(--thead-text);
   z-index: 220;                 /* above the plate */
@@ -582,7 +584,11 @@ body::before{
 .table-scroll thead th:first-child::before{ content: none; }
 
 /* Keep body rows below the header */
-.table-scroll tbody{ position: relative; z-index: 0; }
+.table-scroll tbody{
+  position: relative;
+  z-index: 0;
+  transform: translateY(var(--thead-gap, 0px));
+}
 .table-scroll tbody tr{ position: relative; z-index: 0; }
 
 /* optional: keep vertical scrollbar width constant on all pages */
@@ -910,9 +916,9 @@ body::before{
 /* Single rounded bar behind the <th> cells */
 .thead-plate{
   position: sticky;
-  top: var(--ui-offset, var(--sticky-controls-offset, 0px));
-  height: var(--thead-height, 40px);
-  margin-bottom: calc(-1 * var(--thead-height, 40px));
+  top: calc(var(--ui-offset, var(--sticky-controls-offset, 0px)) - var(--thead-natural-top, 0px));
+  height: calc(var(--thead-height, 40px) + var(--thead-gap, 0px));
+  margin-bottom: calc(-1 * (var(--thead-height, 40px) + var(--thead-gap, 0px)));
 
   /* soft gradient so it feels less “blocky” */
   background: linear-gradient(
@@ -992,15 +998,15 @@ thead th[data-sort] .sort-arrow{ opacity:1; }
 }
 
 /* === FINAL OVERRIDE: sticky header uses dynamic UI offset === */
-.table-scroll thead th{
+.table-scroll thead th{ 
   position: sticky;
-  top: var(--ui-offset, var(--sticky-controls-offset, 0px));
+  top: calc(var(--ui-offset, var(--sticky-controls-offset, 0px)) - var(--thead-natural-top, 0px));
 }
 .thead-plate{
   position: sticky;
-  top: var(--ui-offset, var(--sticky-controls-offset, 0px));
-  height: var(--thead-height, 40px);
-  margin-bottom: calc(-1 * var(--thead-height, 40px));
+  top: calc(var(--ui-offset, var(--sticky-controls-offset, 0px)) - var(--thead-natural-top, 0px));
+  height: calc(var(--thead-height, 40px) + var(--thead-gap, 0px));
+  margin-bottom: calc(-1 * (var(--thead-height, 40px) + var(--thead-gap, 0px)));
 }
     
   </style>
@@ -1310,19 +1316,27 @@ function updateUiOffset(){
   const rule   = document.querySelector('.top-rule');
   const sticky = document.querySelector('.sticky-top');
 
-  const rectH = el => (el ? el.getBoundingClientRect().height : 0);
-  const mb    = el => (el ? parseFloat(getComputedStyle(el).marginBottom) || 0 : 0);
+  const measureBottom = el => {
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom <= 0) return 0;
+    const styles = getComputedStyle(el);
+    const marginBottom = parseFloat(styles.marginBottom) || 0;
+    return rect.bottom + marginBottom;
+  };
 
-  // How much of the title+rule is still visible at the top of the viewport?
-  const headAndRuleTotal = rectH(head) + rectH(rule);
-  const scrolledPast     = Math.min(window.scrollY || 0, headAndRuleTotal);
-  const headAndRuleInView = Math.max(0, headAndRuleTotal - scrolledPast);
+  const offset = Math.max(
+    measureBottom(head),
+    measureBottom(rule),
+    measureBottom(sticky)
+  );
 
-  // Sticky block stays in view; include its margin-bottom to match layout.
-  const stickyBlock = rectH(sticky) + mb(sticky);
+  const activeTable = document.querySelector('.dash-table[data-active="true"] table');
+  const naturalTop = activeTable ? activeTable.getBoundingClientRect().top : 0;
 
-  const offset = Math.round(headAndRuleInView + stickyBlock);
-  document.documentElement.style.setProperty('--ui-offset', `${offset}px`);
+  document.documentElement.style.setProperty('--ui-offset', `${Math.round(offset)}px`);
+  document.documentElement.style.setProperty('--thead-natural-top', `${Math.round(naturalTop)}px`);
+  document.documentElement.style.setProperty('--thead-gap', `${Math.max(0, Math.round(offset - naturalTop))}px`);
 }
 
 // keep both helpers in sync (either keep your old one or just call this)


### PR DESCRIPTION
## Summary
- adjust sticky header math to use actual viewport geometry so the header stays directly beneath the controls
- offset table body rows with a transform and extend the header plate so data never appears above the column labels

## Testing
- Manually opened index.html in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e05446280c8326911e34dc0f1b81ce