### PR TITLE
Restore dashboard markup and fix UI wiring

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,147 @@ thead th[data-sort] .sort-arrow{opacity:1}
 .table-scroll thead th{position:sticky;top:var(--ui-offset,var(--sticky-controls-offset,0px))!important;z-index:220;background:transparent;color:var(--thead-text);font-weight:800;letter-spacing:.2px;padding:10px}
 .thead-plate{position:sticky;top:var(--ui-offset,var(--sticky-controls-offset,0px))!important;height:var(--thead-height,40px);margin-bottom:calc(-1 * var(--thead-height,40px));z-index:210;background:var(--thead);box-shadow:0 1px 0 rgba(0,0,0,.25),inset 0 1px 0 rgba(255,255,255,.05)}
 </style>
+</head>
+<body class="light">
+  <div class="page">
+    <header class="page-head">
+      <div class="page-head__title">
+        <h1 class="title">Work Orders Dashboard</h1>
+        <span class="week-badge" id="week-badge" aria-live="polite">Loading…</span>
+      </div>
+      <img src="LOGOlesswhitespace.png" alt="Aberdeen Laundry Services logo" class="logo" />
+    </header>
+
+    <div class="top-rule" aria-hidden="true"></div>
+
+    <main>
+      <div class="legend-popover">
+        <button id="legendBtn" class="btn btn--pill" type="button" aria-haspopup="dialog" aria-expanded="false">Legend</button>
+        <div class="legend-popover__panel" role="dialog" aria-modal="false" aria-label="Legend">
+          <div class="legend legend--compact">
+            <p class="legend__title">How to read this dashboard</p>
+            <ul class="legend__list">
+              <li class="legend__sample">
+                <span><span class="legend__rail"></span> Priority</span>
+                <span>Rows with the Priority tag are highlighted.</span>
+              </li>
+              <li class="legend__sample">
+                <span><span class="status-chip open">Open</span></span>
+                <span>Status chips show the live state of a work order.</span>
+              </li>
+              <li class="legend__sample">
+                <span><span class="age-chip age-old">14d</span></span>
+                <span>Age chips measure how long the order has been active.</span>
+              </li>
+              <li class="legend__sample">
+                <span><span class="chip-cat">Category</span></span>
+                <span>Category chips map directly to the sheet.</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="legend legend--full">
+        <p class="legend__title">Legend</p>
+        <ul class="legend__list">
+          <li class="legend__sample">
+            <span><span class="legend__rail"></span> Priority</span>
+            <span>Rows with the Priority tag are highlighted.</span>
+          </li>
+          <li class="legend__sample">
+            <span><span class="status-chip open">Open</span></span>
+            <span>Status chips show the live state of a work order.</span>
+          </li>
+          <li class="legend__sample">
+            <span><span class="age-chip age-old">14d</span></span>
+            <span>Age chips measure how long the order has been active.</span>
+          </li>
+          <li class="legend__sample">
+            <span><span class="chip-cat">Category</span></span>
+            <span>Category chips map directly to the sheet.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="sticky-top" data-collapsed="false">
+        <div class="sticky-top__bar">
+          <button id="collapseBtn" class="btn btn--pill" type="button" aria-expanded="true">Hide controls</button>
+        </div>
+        <div class="sticky-content">
+          <div class="controls">
+            <input id="globalSearch" class="search-input" type="search" placeholder="Search work orders…" aria-label="Search work orders" />
+
+            <div class="filter-group week-picker">
+              <button id="weekPrev" class="btn btn--pill" type="button" data-week-nav="prev" aria-label="View previous week">‹ Prev</button>
+              <div id="weekPicker" aria-live="polite"></div>
+              <button id="weekNext" class="btn btn--pill" type="button" data-week-nav="next" aria-label="View next week">Next ›</button>
+            </div>
+
+            <div class="filter-group">
+              <label for="statusFilter">Status</label>
+              <select id="statusFilter">
+                <option value="">All statuses</option>
+                <option value="Open">Open</option>
+                <option value="In Progress">In Progress</option>
+                <option value="On Hold">On Hold</option>
+                <option value="Done">Done</option>
+              </select>
+            </div>
+
+            <div class="filter-group">
+              <label for="priorityFilter">Priority</label>
+              <select id="priorityFilter">
+                <option value="">All priorities</option>
+                <option value="Critical">Critical</option>
+                <option value="High">High</option>
+                <option value="Medium">Medium</option>
+                <option value="Low">Low</option>
+              </select>
+            </div>
+
+            <label class="btn" for="file">Import CSV/JSON</label>
+            <input id="file" class="visually-hidden" type="file" accept=".csv,.tsv,.json,text/csv,text/tab-separated-values" />
+
+            <button id="refreshBtn" class="btn" type="button">Refresh data</button>
+            <button id="exportCsvBtn" class="btn" type="button" disabled>Export CSV</button>
+            <button id="themeBtn" class="btn btn--pill" type="button" aria-pressed="false">Dark mode</button>
+          </div>
+
+          <div id="activeFilterChips" class="active-filter-chips" hidden></div>
+
+          <nav class="nav" role="tablist" aria-label="Dashboard views">
+            <button class="tab" type="button" role="tab" aria-selected="true" aria-controls="dash-all">All sites</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="dash-ek">East Kilbride</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="dash-mm">Mugiemoss</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="dash-keith">Keith</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="dash-by">Byron</button>
+          </nav>
+        </div>
+      </div>
+
+      <div class="kpi-panels">
+        <section class="dash-kpis" data-site="all"></section>
+        <section class="dash-kpis" data-site="ek" hidden></section>
+        <section class="dash-kpis" data-site="mm" hidden></section>
+        <section class="dash-kpis" data-site="keith" hidden></section>
+        <section class="dash-kpis" data-site="by" hidden></section>
+      </div>
+
+      <section class="dashboards">
+        <section id="dash-all" class="dash dash-table" data-site="all" data-active="true"></section>
+        <section id="dash-ek" class="dash dash-table" data-site="ek" hidden></section>
+        <section id="dash-mm" class="dash dash-table" data-site="mm" hidden></section>
+        <section id="dash-keith" class="dash dash-table" data-site="keith" hidden></section>
+        <section id="dash-by" class="dash dash-table" data-site="by" hidden></section>
+      </section>
+    </main>
+  </div>
+  <div id="loadingOverlay" style=" position:fixed; inset:0; display:none; place-items:center; background:color-mix(in srgb, var(--paper) 70%, transparent); z-index:9999;">
+    <div style="padding:10px 14px;border:1px solid var(--grid);border-radius:10px;background:var(--paper);font-weight:800">
+      Loading…
+    </div>
+  </div>
 <script>
 
   let __loadController = null;
@@ -2026,6 +2167,11 @@ function setActiveDash(id){
     sec.hidden = !isMatch;
   });
 
+  document.querySelectorAll('.dash-kpis').forEach(panel => {
+    const isMatch = panel.dataset.site === site;
+    panel.hidden = !isMatch;
+  });
+
   // sync tabs safely
   document.querySelectorAll('.nav .tab').forEach(t => {
     const controls = t.getAttribute('aria-controls');
@@ -2257,13 +2403,6 @@ document.fonts?.ready?.then(() => {
     updateStickyControlsOffset();
   } catch {}
 });
-</script> <!-- ← keep this closing tag -->
-  <div id="loadingOverlay" style="
- position:fixed; inset:0; display:none; place-items:center;
- background:color-mix(in srgb, var(--paper) 70%, transparent); z-index:9999;">
-  <div style="padding:10px 14px;border:1px solid var(--grid);border-radius:10px;background:var(--paper);font-weight:800">
-    Loading…
-  </div>
-</div>
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reintroduce the dashboard layout, controls, and legend markup so the page renders again
- keep the loading overlay and scripts at the end of the body so DOM queries succeed
- hide inactive KPI panels alongside their matching dashboard tab

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1311cddc08326ab9e957b2a6ec338