### PR TITLE
Remove duplicate `getPersonDaySet` and orphan refs in `buildPlanView` wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -8725,19 +8725,6 @@ document.addEventListener('keydown', (e)=>{
       }
       return seenWorkOrdersByPersonDay.get(key);
     };
-    const personKey = (person) => String(person ?? '').trim().toLowerCase();
-    const getPersonDaySet = (day, person) => {
-      const dKey = dayKey(day);
-      if(!seenWorkOrdersByDayAndPerson.has(dKey)){
-        seenWorkOrdersByDayAndPerson.set(dKey, new Map());
-      }
-      const perDay = seenWorkOrdersByDayAndPerson.get(dKey);
-      const pKey = personKey(person);
-      if(!perDay.has(pKey)){
-        perDay.set(pKey, new Set());
-      }
-      return perDay.get(pKey);
-    };
     const normalizeWoId = (entry) => {
       if (!entry) return null;
       if (entry.lookupId) return entry.lookupId;


### PR DESCRIPTION
### Motivation
- The trailing monkey-patch wrapper for `buildPlanView` contained two implementations of `getPersonDaySet` and a discarded branch that referenced out-of-scope symbols, which risks runtime errors and ambiguous deduplication behavior.

### Description
- Removed the duplicate `getPersonDaySet` declaration and kept the single day/person-scoped dedupe implementation that uses a `Map` of `Set`s to track seen work orders.
- Deleted the discarded branch that referenced undeclared symbols (`dayKey` and `seenWorkOrdersByDayAndPerson`) and its associated `personKey` helper to eliminate orphan references.
- Preserved the existing cleanup behavior so the wrapper still filters placeholder/note-like entries, deduplicates work order cards per day/person, and safely returns `out` only when `out.matrix` is present.

### Testing
- Ran a code search with `rg -n "const getPersonDaySet|dayKey\(|seenWorkOrdersByDayAndPerson|personKey" index.html` to confirm the duplicate helper and orphan symbols were removed, and the single `getPersonDaySet` remains; the check succeeded.
- Inspected the updated `index.html` diff to verify the discarded branch was removed and the active cleanup path is unchanged; the inspection succeeded.
- Performed a commit of the updated file to record the change; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcb06515c83268e7dd003684241c9)