### PR TITLE
PPM Weekly Asset View: use shared MaintainX work order pipeline

### DIFF
--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -1,15 +1,8 @@
 (function(global){
   'use strict';
 
-  const FIELD_ALIASES = Object.freeze({
-    woNumber: ['ID', 'WO', 'WO Number', 'Work Order', 'Work Order Number', 'WO/Link', 'Reference', 'Number'],
-    category: ['Categories', 'Category', 'Type', 'Classification'],
-    asset: ['Asset', 'Asset Name', 'Asset ID', 'Asset Description', 'Equipment', 'Equipment Name', 'Name', 'Title'],
-    site: ['Location', 'Site', 'Facility'],
-    status: ['Status', 'State'],
-    dueDate: ['Due date', 'Due Date', 'Planned Start Date', 'Planned Start', 'Planned Start Date (Local)'],
-    title: ['Title', 'Description', 'Task', 'Summary', 'Asset', 'Asset Name']
-  });
+  const SHEET_INDEX_CSV_URL =
+    'https://docs.google.com/spreadsheets/d/e/2PACX-1vRJocigDhxneJtrUmezFU7FcWpzSSah8-Wb6Rce8NA1f7jKcINgYU29iYRqt5QQymWATX5zs5k8_rK0/pub?single=true&output=csv&gid=105348743';
 
   const ACTIVE_STATUS_ALLOWLIST = [
     'open',
@@ -46,12 +39,228 @@
     return toStringSafe(value).toLowerCase();
   }
 
+  function slugify(s){
+    return String(s || '')
+      .toLowerCase()
+      .trim()
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function parseDelimited(text){
+    const sep = text.includes('\t') ? '\t' : ',';
+    const rows = text.trim().split(/\r?\n/).map(r =>
+      r.split(new RegExp(`${sep}(?=(?:[^"]*"[^"]*")*[^"]*$)`)).map(c => c.replace(/^"|"$/g,''))
+    );
+    const rawHeaders = rows.shift() || [];
+    const headers = rawHeaders.map((h, i)=>String(h ?? '').replace(/^\uFEFF/, '').trim() || `col${i}`);
+    const data = rows.map(r => Object.fromEntries(r.map((v, i)=>[headers[i] || `col${i}`, v])));
+    return { headers, rows: data };
+  }
+
+  function parseDateLoose(v){
+    if(!v) return null;
+    const str = String(v).trim();
+    if(!str) return null;
+
+    const iso = str.match(/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2}))?)?$/);
+    if(iso){
+      const [,y,M,d,hh='00',mm='00',ss='00'] = iso;
+      const dt = new Date(`${y}-${M}-${d}T${hh.padStart(2,'0')}:${mm}:${ss.padStart(2,'0')}`);
+      return Number.isNaN(dt.getTime()) ? null : dt;
+    }
+
+    const slashed = str.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s+(\d{1,2}):(\d{2}))?$/);
+    if(!slashed) return null;
+    let [,d,M,y,hh='00',mm='00'] = slashed;
+    d = d.padStart(2,'0');
+    M = M.padStart(2,'0');
+    hh = hh.padStart(2,'0');
+    const dt = new Date(`${y}-${M}-${d}T${hh}:${mm}:00`);
+    return Number.isNaN(dt.getTime()) ? null : dt;
+  }
+
+  function parseWeekEndDate(weekEnd){
+    if(!weekEnd) return null;
+    const parsed = parseDateLoose(weekEnd);
+    if(parsed) return parsed;
+    const dt = new Date(String(weekEnd));
+    return Number.isNaN(dt.getTime()) ? null : dt;
+  }
+
+  function withBust(u){
+    const x = new URL(u);
+    x.searchParams.set('_ts', Date.now());
+    return x.toString();
+  }
+
+  function csvUrlForGid(gid){
+    const u = new URL(SHEET_INDEX_CSV_URL);
+    u.searchParams.set('gid', String(gid));
+    u.searchParams.set('single', 'true');
+    u.searchParams.set('output', 'csv');
+    return u.toString();
+  }
+
+  function sanitizePlanScalar(value){
+    if(value == null) return null;
+    if(typeof value === 'string'){
+      const trimmed = value.trim();
+      if(!trimmed || trimmed === '-' || /^null$/i.test(trimmed) || /^undefined$/i.test(trimmed)) return null;
+      return trimmed;
+    }
+    if(typeof value === 'number') return Number.isFinite(value) ? String(value) : null;
+    if(typeof value === 'boolean') return value ? '1' : null;
+    return null;
+  }
+
+  async function loadWeeksIndex({ bust = false } = {}){
+    const finalUrl = bust ? withBust(SHEET_INDEX_CSV_URL) : SHEET_INDEX_CSV_URL;
+    const res = await fetch(finalUrl, { cache: bust ? 'reload' : 'no-store' });
+    if(!res.ok) throw new Error('Index load failed: ' + res.status);
+
+    const text = await res.text();
+    if(!text || !text.trim()) throw new Error('Index CSV was empty');
+
+    const { headers, rows } = parseDelimited(text);
+    const normHeaders = headers.map(h => String(h || '').trim());
+    const findHeader = (...candidates) => {
+      const wanted = candidates.map(c => String(c).trim().toLowerCase());
+      const idx = normHeaders.findIndex(h => wanted.includes(h.toLowerCase()));
+      return idx >= 0 ? headers[idx] : null;
+    };
+
+    const H_LABEL = findHeader('label', 'week label', 'title', 'name');
+    const H_WEEKEND = findHeader('week_end', 'week end', 'week', 'weekending', 'week-ending', 'week_end_date', 'date', 'week ending (iso)');
+    const H_GID = findHeader('gid', 'sheet_gid', 'tab_gid', 'tab id', 'sheet id', 'sheetid', 'tabid', 'sheet');
+    const H_URL = findHeader('url', 'sheet url', 'link');
+
+    if(!H_GID && !H_URL){
+      throw new Error('Index is missing a "gid" or "url" column');
+    }
+
+    const gidFromUrl = (u) => {
+      if(!u) return null;
+      const m = String(u).match(/[?#&]gid=(\d+)/);
+      return m ? m[1] : null;
+    };
+
+    const out = rows.map(r => {
+      const label = H_LABEL ? r[H_LABEL] : (r[H_WEEKEND] || '').trim();
+      const weekEnd = H_WEEKEND ? r[H_WEEKEND] : '';
+      const urlRaw = H_URL ? String(r[H_URL] || '').trim() : '';
+      let gid = sanitizePlanScalar(H_GID ? r[H_GID] : null);
+      if(!gid && urlRaw) gid = gidFromUrl(urlRaw);
+      const url = sanitizePlanScalar(urlRaw) || (urlRaw || null);
+
+      return { label, weekEnd, gid: gid || null, url };
+    }).filter(x => x && (x.gid || x.url));
+
+    out.sort((a,b) => {
+      const aDate = parseWeekEndDate(a.weekEnd)?.getTime() || 0;
+      const bDate = parseWeekEndDate(b.weekEnd)?.getTime() || 0;
+      if(aDate !== bDate) return bDate - aDate;
+      return String(b.label || '').localeCompare(String(a.label || ''), undefined, { numeric:true, sensitivity:'base' });
+    });
+
+    return out;
+  }
+
+  function chooseInitialWeek(weeks){
+    const q = new URLSearchParams(global.location?.search || '');
+    const byGid = q.get('gid');
+    const byDate = q.get('week');
+    const forceLatest = q.get('latest') === '1';
+
+    let chosen = null;
+    if(byGid) chosen = weeks.find(w => String(w.gid) === String(byGid));
+    if(!chosen && byDate) chosen = weeks.find(w => String(w.weekEnd) === String(byDate));
+    if(!chosen && !forceLatest){
+      try {
+        const last = global.localStorage?.getItem('alsLastWeekEnd');
+        if(last) chosen = weeks.find(w => String(w.weekEnd) === last);
+      } catch {}
+    }
+    return chosen || weeks[0] || null;
+  }
+
+  function normalizeId(v){
+    return String(v ?? '')
+      .trim()
+      .replace(/^WO-?/i,'')
+      .replace(/[^\w]/g,'')
+      .toLowerCase();
+  }
+
+  function bestTimestamp(r){
+    return (parseDateLoose(r['Last updated'])?.getTime())
+      || (parseDateLoose(r['Completed on'])?.getTime())
+      || (parseDateLoose(r['Created on'])?.getTime())
+      || 0;
+  }
+
+  function dedupeRows(rows){
+    const map = new Map();
+    for(const r of (rows || [])){
+      const id = normalizeId(r['ID']);
+      const fallback = String(r['Title'] || '').trim().toLowerCase()
+        + '|' + (parseDateLoose(r['Created on'])?.toISOString()?.slice(0,10) || '');
+      const key = id || fallback;
+
+      const prev = map.get(key);
+      if(!prev){
+        map.set(key, r);
+        continue;
+      }
+      if(bestTimestamp(r) > bestTimestamp(prev)){
+        map.set(key, r);
+      }
+    }
+    return [...map.values()];
+  }
+
+  function toSiteKey(loc){
+    const s = String(loc || '').toLowerCase();
+    if(s.includes('byron')) return 'by';
+    if(s.includes('mugiemoss') || s.includes('bucksburn')) return 'mm';
+    if(s.includes('keith')) return 'keith';
+    if(s.includes('cathkin') || s.includes('east kilbride') || s.includes('ek')) return 'ek';
+    return 'other';
+  }
+
+  const SITE_KEY_LABELS = Object.freeze({
+    all: 'All',
+    ek: 'East Kilbride',
+    mm: 'Mugiemoss',
+    keith: 'Keith',
+    by: 'Byron',
+    other: 'Other'
+  });
+
+  function statusClass(v){
+    const map = new Map([
+      ['done','done'],
+      ['complete','done'],
+      ['completed','done'],
+      ['open','open'],
+      ['in-progress','in-progress'],
+      ['in progress','in-progress'],
+      ['progress','in-progress'],
+      ['inprogress','in-progress'],
+      ['on-hold','on-hold'],
+      ['on hold','on-hold'],
+      ['hold','on-hold'],
+      ['onhold','on-hold']
+    ]);
+    const s = slugify(String(v || ''));
+    return map.get(s) || s;
+  }
+
   function parseDateValue(value){
     if(value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
-    const text = toStringSafe(value);
-    if(!text) return null;
-    const parsed = new Date(text);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
+    return parseDateLoose(value);
   }
 
   function startOfDay(date){
@@ -59,52 +268,59 @@
     return new Date(date.getFullYear(), date.getMonth(), date.getDate());
   }
 
-  function extractField(raw, aliases){
-    if(!raw || typeof raw !== 'object') return '';
-    for(const key of aliases){
-      if(Object.prototype.hasOwnProperty.call(raw, key)){
-        const direct = toStringSafe(raw[key]);
-        if(direct) return direct;
-      }
-    }
+  function startOfWeek(date){
+    const d = new Date(date);
+    const day = d.getDay();
+    const mondayOffset = (day + 6) % 7;
+    d.setDate(d.getDate() - mondayOffset);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
 
-    const lowered = new Map();
-    for(const [key, value] of Object.entries(raw)){
-      const cleaned = normalizeKey(key);
-      if(!cleaned || lowered.has(cleaned)) continue;
-      lowered.set(cleaned, value);
+  function extractField(raw, names){
+    for(const name of names){
+      const value = raw?.[name];
+      const text = toStringSafe(value);
+      if(text) return text;
     }
-
-    for(const key of aliases){
-      const fallback = lowered.get(normalizeKey(key));
-      const cleaned = toStringSafe(fallback);
-      if(cleaned) return cleaned;
-    }
-
     return '';
   }
 
-  function mapMaintainXRow(raw){
-    const woNumber = extractField(raw, FIELD_ALIASES.woNumber);
-    const category = extractField(raw, FIELD_ALIASES.category);
-    const assetName = extractField(raw, FIELD_ALIASES.asset);
-    const site = extractField(raw, FIELD_ALIASES.site);
-    const status = extractField(raw, FIELD_ALIASES.status);
-    const dueDateRaw = extractField(raw, FIELD_ALIASES.dueDate);
-    const dueDate = parseDateValue(dueDateRaw);
-    const title = extractField(raw, FIELD_ALIASES.title) || assetName;
+  function getNormalizedWorkOrders(rawData){
+    const list = Array.isArray(rawData) ? rawData : [];
+    return list.map((row, idx) => {
+      const woNumber = extractField(row, ['ID', 'WO', 'WO Number', 'Work Order', 'Work Order Number', 'WO/Link']);
+      const title = extractField(row, ['Title', 'Description', 'Task', 'Summary']);
+      const category = extractField(row, ['Categories', 'Category', 'Type', 'Classification']);
+      const status = extractField(row, ['Status', 'State']);
+      const site = extractField(row, ['Location', 'Site', 'Facility']);
+      const asset = extractField(row, ['Asset', 'Asset Name', 'Equipment', 'Equipment Name']);
+      const dueDateRaw = extractField(row, ['Due date', 'Due Date', 'Planned Start Date', 'Planned Start', 'Planned Start Date (Local)', 'Scheduled date', 'Scheduled Date']);
+      const dueDate = parseDateValue(dueDateRaw);
+      return {
+        id: woNumber || `row-${idx}`,
+        woNumber,
+        title,
+        category,
+        status,
+        statusKey: statusClass(status),
+        site,
+        siteKey: toSiteKey(site),
+        assetName: asset,
+        dueDateRaw,
+        dueDate,
+        raw: row
+      };
+    });
+  }
 
-    return {
-      woNumber,
-      category,
-      assetName,
-      site,
-      status,
-      dueDateRaw,
-      dueDate,
-      title,
-      raw
-    };
+  function isPPMCategory(categoryValue){
+    const raw = toStringSafe(categoryValue);
+    if(!raw) return false;
+    const normalized = raw.replace(/\//g, ',');
+    const parts = normalized.split(/[;,]+/).map(part => normalizeKey(part)).filter(Boolean);
+    if(parts.length === 0) return /\bppm\b/i.test(raw);
+    return parts.some(part => /\bppm\b/i.test(part));
   }
 
   function isActivePlanningStatus(status){
@@ -114,18 +330,14 @@
     return ACTIVE_STATUS_ALLOWLIST.some(token => normalized.includes(token));
   }
 
-  function isPPMCategory(categoryValue){
-    if(Array.isArray(categoryValue)){
-      return categoryValue.some(isPPMCategory);
-    }
-    const raw = toStringSafe(categoryValue);
-    if(!raw) return false;
-    const normalized = raw.replace(/\//g, ',');
-    const parts = normalized.split(/[;,]+/).map(part => normalizeKey(part)).filter(Boolean);
-    if(parts.length === 0){
-      return /\bppm\b/i.test(raw);
-    }
-    return parts.some(part => /\bppm\b/i.test(part));
+  function getActivePPMWorkOrders(workOrders){
+    return (Array.isArray(workOrders) ? workOrders : []).filter(order => {
+      if(!isPPMCategory(order.category)) return false;
+      if(!isActivePlanningStatus(order.status)) return false;
+      if(!order.assetName) return false;
+      if(!order.woNumber) return false;
+      return true;
+    });
   }
 
   function computeWeekBucket(date, selectedPeriodStart){
@@ -153,115 +365,143 @@
     return { week1: [], week2: [], week3: [] };
   }
 
-  function buildPPMPlannerModel(rawRows, { siteKey = 'all', selectedPeriodStart } = {}){
-    const mappedRows = (Array.isArray(rawRows) ? rawRows : []).map(mapMaintainXRow);
+  function groupPPMWorkOrdersByAssetAndWeek(workOrders, selectedSite, selectedPeriodStart){
+    const filteredSiteKey = selectedSite && selectedSite !== 'all' ? selectedSite : 'all';
+    const bySite = new Map();
 
-    const malformed = {
-      missingCoreFields: [],
-      invalidDates: []
-    };
+    for(const order of (Array.isArray(workOrders) ? workOrders : [])){
+      if(filteredSiteKey !== 'all' && order.siteKey !== filteredSiteKey) continue;
 
-    const siteOrder = [];
-    const assetsBySite = {};
+      const bucket = computeWeekBucket(order.dueDate || order.dueDateRaw, selectedPeriodStart);
+      if(bucket === 'outOfRange') continue;
 
-    for(const row of mappedRows){
-      if(!isPPMCategory(row.category)) continue;
-      if(!isActivePlanningStatus(row.status)) continue;
+      const siteKey = order.siteKey || 'other';
+      if(!bySite.has(siteKey)) bySite.set(siteKey, new Map());
+      const assets = bySite.get(siteKey);
 
-      if(!row.woNumber || !row.assetName || !row.site){
-        malformed.missingCoreFields.push({
-          woNumber: row.woNumber,
-          assetName: row.assetName,
-          site: row.site,
-          status: row.status,
-          category: row.category
-        });
-        continue;
+      const assetName = order.assetName;
+      if(!assets.has(assetName)){
+        assets.set(assetName, { assetName, siteKey, site: order.site || SITE_KEY_LABELS[siteKey] || 'Unknown', weeks: createEmptyWeeks() });
       }
 
-      const weekBucket = computeWeekBucket(row.dueDate || row.dueDateRaw, selectedPeriodStart);
-      if(weekBucket === 'outOfRange'){
-        if(!row.dueDate){
-          malformed.invalidDates.push({ woNumber: row.woNumber, dueDateRaw: row.dueDateRaw });
-        }
-        continue;
-      }
-
-      const siteName = row.site;
-      if(siteKey !== 'all' && normalizeKey(siteName) !== normalizeKey(siteKey)) continue;
-
-      if(!assetsBySite[siteName]){
-        assetsBySite[siteName] = [];
-        siteOrder.push(siteName);
-      }
-
-      let assetEntry = assetsBySite[siteName].find(item => item.assetName === row.assetName);
-      if(!assetEntry){
-        assetEntry = {
-          assetName: row.assetName,
-          weeks: createEmptyWeeks()
-        };
-        assetsBySite[siteName].push(assetEntry);
-      }
-
-      assetEntry.weeks[weekBucket].push({
-        woNumber: row.woNumber,
-        title: row.title,
-        status: row.status,
-        dueDate: row.dueDate,
-        dueDateRaw: row.dueDateRaw,
-        category: row.category,
-        site: row.site,
-        raw: row.raw
-      });
+      assets.get(assetName).weeks[bucket].push(order);
     }
 
+    const sites = [...bySite.keys()].sort((a, b) => {
+      const rank = ['ek', 'mm', 'keith', 'by', 'other'];
+      const ia = rank.indexOf(a);
+      const ib = rank.indexOf(b);
+      if(ia !== ib) return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+      return a.localeCompare(b, undefined, { sensitivity: 'base' });
+    });
+
+    const assetsBySite = {};
     const rows = [];
-    let totalWorkOrders = 0;
     let totalAssets = 0;
+    let totalWorkOrders = 0;
 
-    for(const site of siteOrder){
-      const siteAssets = assetsBySite[site]
-        .filter(asset => (asset.weeks.week1.length + asset.weeks.week2.length + asset.weeks.week3.length) > 0)
-        .sort((a, b) => a.assetName.localeCompare(b.assetName, undefined, { sensitivity: 'base' }));
+    for(const siteKey of sites){
+      const sortedAssets = [...bySite.get(siteKey).values()]
+        .sort((a,b) => a.assetName.localeCompare(b.assetName, undefined, { sensitivity: 'base' }));
 
-      assetsBySite[site] = siteAssets;
-      totalAssets += siteAssets.length;
+      assetsBySite[siteKey] = sortedAssets;
+      totalAssets += sortedAssets.length;
 
-      for(const asset of siteAssets){
+      sortedAssets.forEach(asset => {
         totalWorkOrders += asset.weeks.week1.length + asset.weeks.week2.length + asset.weeks.week3.length;
         rows.push(asset);
-      }
-    }
-
-    if(malformed.missingCoreFields.length || malformed.invalidDates.length){
-      console.warn('[PPM Planner] Malformed rows skipped:', {
-        missingCoreFields: malformed.missingCoreFields,
-        invalidDates: malformed.invalidDates
       });
     }
 
     return {
-      sites: siteOrder.filter(site => assetsBySite[site] && assetsBySite[site].length > 0),
+      sites,
       assetsBySite,
       rows,
       summary: {
-        totalRowsInput: Array.isArray(rawRows) ? rawRows.length : 0,
-        totalPPMRowsMapped: mappedRows.length,
         totalAssets,
-        totalWorkOrders,
-        malformed
+        totalWorkOrders
+      }
+    };
+  }
+
+  async function loadMaintainXRawData({ bust = false } = {}){
+    const weeks = await loadWeeksIndex({ bust });
+    if(!Array.isArray(weeks) || !weeks.length){
+      throw new Error('No week entries were found in the MaintainX index sheet.');
+    }
+
+    const selectedWeek = chooseInitialWeek(weeks);
+    if(!selectedWeek) throw new Error('Could not resolve a selected week from the index sheet.');
+
+    let sourceUrl = selectedWeek.url || null;
+    if(!sourceUrl && selectedWeek.gid != null){
+      sourceUrl = csvUrlForGid(selectedWeek.gid);
+    }
+    if(!sourceUrl){
+      throw new Error('Selected week is missing both URL and gid source references.');
+    }
+
+    const res = await fetch(sourceUrl, { cache: 'no-store' });
+    if(!res.ok){
+      throw new Error(`MaintainX week load failed (${res.status} ${res.statusText})`);
+    }
+
+    const text = await res.text();
+    if(!text || !text.trim()){
+      throw new Error('MaintainX week CSV is empty.');
+    }
+
+    const parsed = parseDelimited(text);
+    const dedupedRows = dedupeRows(parsed.rows || []);
+
+    return {
+      selectedWeek,
+      headers: parsed.headers || [],
+      rawRows: dedupedRows
+    };
+  }
+
+  async function buildPPMPlannerModelFromMaintainX(options = {}){
+    const source = await loadMaintainXRawData(options);
+    const normalized = getNormalizedWorkOrders(source.rawRows);
+    const activePPM = getActivePPMWorkOrders(normalized);
+    const selectedPeriodStart = options.selectedPeriodStart || startOfWeek(new Date());
+    const grouped = groupPPMWorkOrdersByAssetAndWeek(activePPM, options.siteKey || 'all', selectedPeriodStart);
+
+    return {
+      ...grouped,
+      selectedWeek: source.selectedWeek,
+      summary: {
+        ...grouped.summary,
+        totalRowsInput: source.rawRows.length,
+        totalNormalizedRows: normalized.length,
+        totalActivePPMRows: activePPM.length
       }
     };
   }
 
   const api = {
-    FIELD_ALIASES,
-    mapMaintainXRow,
-    isActivePlanningStatus,
-    isPPMCategory,
-    computeWeekBucket,
-    buildPPMPlannerModel
+    SHEET_INDEX_CSV_URL,
+    SITE_KEY_LABELS,
+    loadMaintainXRawData,
+    getNormalizedWorkOrders,
+    getActivePPMWorkOrders,
+    groupPPMWorkOrdersByAssetAndWeek,
+    buildPPMPlannerModelFromMaintainX,
+    buildPPMPlannerModel(rawRows, { siteKey = 'all', selectedPeriodStart } = {}){
+      const normalized = getNormalizedWorkOrders(rawRows);
+      const activePPM = getActivePPMWorkOrders(normalized);
+      const grouped = groupPPMWorkOrdersByAssetAndWeek(activePPM, siteKey, selectedPeriodStart || startOfWeek(new Date()));
+      return {
+        ...grouped,
+        summary: {
+          ...grouped.summary,
+          totalRowsInput: Array.isArray(rawRows) ? rawRows.length : 0,
+          totalNormalizedRows: normalized.length,
+          totalActivePPMRows: activePPM.length
+        }
+      };
+    }
   };
 
   if(typeof module !== 'undefined' && module.exports){

--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -320,25 +320,15 @@
   <script src="ppm-weekly-asset-transform.js"></script>
   <script>
     (function(){
-      const RAW_WORK_ORDERS = [
-        { WO: 'WO-10452', Categories: 'PPM', Asset: 'Boiler Plant 01', Site: 'East Kilbride', Status: 'Open', 'Due Date': '2026-04-14', Title: 'Safety valve test' },
-        { WO: 'WO-10461', Categories: 'PPM', Asset: 'Boiler Plant 01', Site: 'East Kilbride', Status: 'Scheduled', 'Due Date': '2026-04-17', Title: 'Combustion check' },
-        { WO: 'WO-10512', Categories: 'PPM', Asset: 'Boiler Plant 01', Site: 'East Kilbride', Status: 'In Progress', 'Due Date': '2026-04-24', Title: 'Burner service' },
-        { WO: 'WO-10488', Categories: 'PPM', Asset: 'Tunnel Washer 04', Site: 'Mugiemoss', Status: 'On Hold', 'Due Date': '2026-04-22', Title: 'Drive chain inspection' },
-        { WO: 'WO-10544', Categories: 'PPM', Asset: 'Air Compressor C2', Site: 'Mugiemoss', Status: 'Open', 'Due Date': '2026-04-18', Title: 'Bearing lubrication' },
-        { WO: 'WO-10477', Categories: 'PPM', Asset: 'Air Compressor C2', Site: 'Keith', Status: 'Completed', 'Due Date': '2026-04-23', Title: 'Filter replacement' },
-        { WO: 'WO-10503', Categories: 'PPM', Asset: 'Mixer Skid 09 - Very Long Asset Name To Test Overflow Handling', Site: 'Byron', Status: 'Scheduled', 'Due Date': '2026-04-29', Title: 'Pressure cut-out calibration' },
-        { WO: 'WO-20001', Categories: 'Corrective', Asset: 'Boiler Plant 01', Site: 'East Kilbride', Status: 'Open', 'Due Date': '2026-04-16', Title: 'Not PPM, should be filtered out' },
-        { WO: 'WO-20002', Categories: 'PPM', Asset: 'Tunnel Washer 04', Site: 'Mugiemoss', Status: 'Closed', 'Due Date': '2026-04-20', Title: 'Closed, should be filtered out' }
-      ];
-
       const plannerSurface = document.querySelector('[data-role="planner-surface"]');
       const siteLabel = document.querySelector('[data-role="site-filter-active"]');
-      const siteButtons = Array.from(document.querySelectorAll('.site-filter__tab'));
+      const siteFilterTabs = document.querySelector('.site-filter__tabs');
       const themeBtn = document.getElementById('dark-toggle');
       const root = document.body;
 
       let selectedSiteKey = 'all';
+      let plannerData = null;
+      let plannerError = null;
 
       function startOfWeek(date){
         const d = new Date(date);
@@ -351,7 +341,7 @@
 
       function cardStatusClass(status){
         const normalized = String(status || '').toLowerCase();
-        if(normalized.includes('complete')) return 'wo-card--green';
+        if(normalized.includes('complete') || normalized.includes('done')) return 'wo-card--green';
         if(normalized.includes('hold')) return 'wo-card--orange';
         if(normalized.includes('progress')) return 'wo-card--blue';
         return 'wo-card--red';
@@ -362,16 +352,8 @@
         const dayLabel = Number.isNaN(date.getTime())
           ? 'Day n/a'
           : date.toLocaleDateString('en-GB', { weekday: 'short' });
-        return `Due ${dayLabel} • ${wo.site || 'Unknown site'}`;
-      }
-
-      function mapPlannerRows(model){
-        return model.rows.map((row) => ({
-          assetName: row.assetName,
-          week1: row.weeks.week1,
-          week2: row.weeks.week2,
-          week3: row.weeks.week3
-        }));
+        const site = wo.site || window.PPMWeeklyAssetTransform.SITE_KEY_LABELS[wo.siteKey] || 'Unknown site';
+        return `Due ${dayLabel} • ${site}`;
       }
 
       function PPMPlannerHeader(){
@@ -406,36 +388,100 @@
         return `
           <div class="planner-row" role="row">
             <div class="planner-cell asset-cell" role="rowheader" title="${row.assetName}">${row.assetName}</div>
-            <div class="planner-cell week-cell" role="gridcell">${renderWeekCards(row.week1)}</div>
-            <div class="planner-cell week-cell" role="gridcell">${renderWeekCards(row.week2)}</div>
-            <div class="planner-cell week-cell" role="gridcell">${renderWeekCards(row.week3)}</div>
+            <div class="planner-cell week-cell" role="gridcell">${renderWeekCards(row.weeks.week1)}</div>
+            <div class="planner-cell week-cell" role="gridcell">${renderWeekCards(row.weeks.week2)}</div>
+            <div class="planner-cell week-cell" role="gridcell">${renderWeekCards(row.weeks.week3)}</div>
           </div>
         `;
       }
 
-      function renderPlanner(){
-        const model = window.PPMWeeklyAssetTransform.buildPPMPlannerModel(RAW_WORK_ORDERS, {
-          siteKey: selectedSiteKey,
-          selectedPeriodStart: startOfWeek(new Date())
+      function renderSiteFilter(siteKeys){
+        const keys = ['all', ...(siteKeys || [])];
+        const labels = window.PPMWeeklyAssetTransform.SITE_KEY_LABELS;
+        siteFilterTabs.innerHTML = keys.map(siteKey => {
+          const text = labels[siteKey] || siteKey;
+          const pressed = selectedSiteKey === siteKey ? 'true' : 'false';
+          return `<button type="button" class="site-filter__tab" data-site-key="${siteKey}" aria-pressed="${pressed}">${text}</button>`;
+        }).join('');
+
+        siteFilterTabs.querySelectorAll('.site-filter__tab').forEach((button) => {
+          button.addEventListener('click', () => {
+            selectedSiteKey = button.dataset.siteKey || 'all';
+            siteFilterTabs.querySelectorAll('.site-filter__tab')
+              .forEach((tab) => tab.setAttribute('aria-pressed', tab === button ? 'true' : 'false'));
+            if(siteLabel) siteLabel.textContent = labels[selectedSiteKey] || selectedSiteKey;
+            renderPlanner();
+          });
         });
 
-        const plannerRows = mapPlannerRows(model);
+        if(siteLabel){
+          siteLabel.textContent = labels[selectedSiteKey] || selectedSiteKey;
+        }
+      }
 
-        const totalWeek1 = plannerRows.reduce((acc, row) => acc + row.week1.length, 0);
-        document.querySelector('[data-kpi="total-work-orders"]').textContent = String(model.summary.totalWorkOrders);
-        document.querySelector('[data-kpi="total-assets"]').textContent = String(model.summary.totalAssets);
+      function renderError(message){
+        plannerSurface.innerHTML = `${PPMPlannerHeader()}<p class="empty-state">${message}</p>`;
+        document.querySelector('[data-kpi="total-work-orders"]').textContent = '0';
+        document.querySelector('[data-kpi="total-assets"]').textContent = '0';
+        document.querySelector('[data-kpi="week1-work-orders"]').textContent = '0';
+      }
+
+      function renderPlanner(){
+        if(plannerError){
+          renderError(plannerError);
+          return;
+        }
+
+        if(!plannerData){
+          renderError('Loading MaintainX work orders…');
+          return;
+        }
+
+        const grouped = window.PPMWeeklyAssetTransform.groupPPMWorkOrdersByAssetAndWeek(
+          plannerData.activePPM,
+          selectedSiteKey,
+          startOfWeek(new Date())
+        );
+
+        const totalWeek1 = grouped.rows.reduce((acc, row) => acc + row.weeks.week1.length, 0);
+        document.querySelector('[data-kpi="total-work-orders"]').textContent = String(grouped.summary.totalWorkOrders);
+        document.querySelector('[data-kpi="total-assets"]').textContent = String(grouped.summary.totalAssets);
         document.querySelector('[data-kpi="week1-work-orders"]').textContent = String(totalWeek1);
 
-        const rowsMarkup = plannerRows.map(PPMAssetRow).join('');
-        const emptyMarkup = plannerRows.length === 0
-          ? '<p class="empty-state">No active PPM work orders found for the selected site and 3-week period.</p>'
+        const rowsMarkup = grouped.rows.map(PPMAssetRow).join('');
+        const selectedWeekLabel = plannerData.selectedWeek?.label || plannerData.selectedWeek?.weekEnd || 'latest published week';
+        const emptyMarkup = grouped.rows.length === 0
+          ? `<p class="empty-state">No active PPM work orders found for the selected site and 3-week period (source: ${selectedWeekLabel}).</p>`
           : '';
 
-        plannerSurface.innerHTML = `
-          ${PPMPlannerHeader()}
-          ${rowsMarkup}
-          ${emptyMarkup}
-        `;
+        plannerSurface.innerHTML = `${PPMPlannerHeader()}${rowsMarkup}${emptyMarkup}`;
+      }
+
+      async function loadPlannerData(){
+        try {
+          const source = await window.PPMWeeklyAssetTransform.loadMaintainXRawData();
+          const normalized = window.PPMWeeklyAssetTransform.getNormalizedWorkOrders(source.rawRows);
+          const activePPM = window.PPMWeeklyAssetTransform.getActivePPMWorkOrders(normalized);
+
+          plannerData = {
+            selectedWeek: source.selectedWeek,
+            activePPM
+          };
+
+          const initialGroup = window.PPMWeeklyAssetTransform.groupPPMWorkOrdersByAssetAndWeek(
+            activePPM,
+            'all',
+            startOfWeek(new Date())
+          );
+
+          renderSiteFilter(initialGroup.sites);
+          renderPlanner();
+        } catch (err){
+          console.error('[PPM Weekly Asset] Failed to load shared MaintainX source', err);
+          plannerError = `MaintainX source unavailable. ${err?.message || 'Could not load shared work order data.'}`;
+          renderSiteFilter([]);
+          renderPlanner();
+        }
       }
 
       function applyTheme(theme){
@@ -461,16 +507,9 @@
         applyTheme(next);
       });
 
-      siteButtons.forEach((button) => {
-        button.addEventListener('click', () => {
-          selectedSiteKey = button.dataset.siteKey || 'all';
-          siteButtons.forEach((tab) => tab.setAttribute('aria-pressed', tab === button ? 'true' : 'false'));
-          if(siteLabel) siteLabel.textContent = button.textContent.trim();
-          renderPlanner();
-        });
-      });
-
+      renderSiteFilter([]);
       renderPlanner();
+      loadPlannerData();
       updateStickyOffset();
       window.addEventListener('resize', updateStickyOffset, { passive:true });
     })();


### PR DESCRIPTION
### Motivation
- The PPM planner was using a hardcoded/demo data array and diverged from the canonical MaintainX source and normalization used by the main Work Orders page. 
- The goal is to ensure the PPM Weekly Asset View consumes the exact same raw MaintainX sheet and shared normalization/filtering logic so both pages remain consistent. 
- The change prevents duplicated business logic and removes silent fallbacks to mock/demo data in production.

### Description
- Reworked the transform module in `ppm-weekly-asset-transform.js` to provide a shared pipeline and helpers including `getNormalizedWorkOrders(rawData)`, `getActivePPMWorkOrders(workOrders)`, `groupPPMWorkOrdersByAssetAndWeek(workOrders, selectedSite, selectedPeriodStart)`, `loadMaintainXRawData()`, and `buildPPMPlannerModelFromMaintainX()` so the PPM view can reuse the same parsing/deduping/site/status normalization used by the main page. 
- Implemented CSV parsing, index/week selection (`loadWeeksIndex`, `chooseInitialWeek`, `csvUrlForGid`), row deduplication, tolerant date parsing, `toSiteKey` site normalization and `statusClass` status normalization inside the shared transform to match main Work Orders behavior. 
- Updated `ppm-weekly-asset.html` to remove the static `RAW_WORK_ORDERS` array and instead asynchronously load the shared MaintainX source, derive active PPM records from the normalized rows, group by site/asset/week, build the site filter tabs from live data, and render the planner using the grouped result. 
- Added explicit error / empty states when the shared source is unavailable and ensured no silent fallback to demo records (sample/demo data was removed from production code). 

### Testing
- Loaded the transform module with `node -e "require('./ppm-weekly-asset-transform.js'); console.log('transform ok')"` and it returned successfully. (passed)
- Exercised the pipeline end-to-end in Node by calling `getNormalizedWorkOrders(...)`, `getActivePPMWorkOrders(...)`, and `groupPPMWorkOrdersByAssetAndWeek(...)` with a sample row to verify normalization, PPM filtering and grouping logic (logged expected counts). (passed)
- Searched the HTML and transform files with `rg` to confirm removal of the hardcoded demo array and to validate the shared API surface exists (`ppm-weekly-asset.html` no longer contains `RAW_WORK_ORDERS`). (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd84525d48326b17d888ad25f3ec2)