### PR TITLE
Add explicit MaintainX source selector and provenance metadata for weekly asset transform

### DIFF
--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -3,6 +3,11 @@
 
   const SHEET_INDEX_CSV_URL =
     'https://docs.google.com/spreadsheets/d/e/2PACX-1vRJocigDhxneJtrUmezFU7FcWpzSSah8-Wb6Rce8NA1f7jKcINgYU29iYRqt5QQymWATX5zs5k8_rK0/pub?single=true&output=csv&gid=105348743';
+  const RAW_WORK_ORDERS_CSV_URL =
+    'https://docs.google.com/spreadsheets/d/1bVi12enMnCmUVmzR_add6e38qFggHwVGwI1PWrIggl4/gviz/tq?tqx=out:csv&sheet=MX_Raw_WorkOrders';
+  const MAINTAINX_SOURCE_CONFIG = Object.freeze({
+    sourceMode: 'selected_week'
+  });
 
   const ACTIVE_STATUS_ALLOWLIST = [
     'open',
@@ -424,37 +429,50 @@
     };
   }
 
-  async function loadMaintainXRawData({ bust = false } = {}){
-    const weeks = await loadWeeksIndex({ bust });
-    if(!Array.isArray(weeks) || !weeks.length){
-      throw new Error('No week entries were found in the MaintainX index sheet.');
+  async function loadMaintainXRawData({ bust = false, sourceMode = MAINTAINX_SOURCE_CONFIG.sourceMode } = {}){
+    const sourceType = sourceMode === 'raw_work_orders' ? 'raw_work_orders' : 'selected_week';
+    let selectedWeek = null;
+    let sourceUrl = null;
+
+    if(sourceType === 'raw_work_orders'){
+      sourceUrl = RAW_WORK_ORDERS_CSV_URL;
+    } else {
+      const weeks = await loadWeeksIndex({ bust });
+      if(!Array.isArray(weeks) || !weeks.length){
+        throw new Error('No week entries were found in the MaintainX index sheet.');
+      }
+
+      selectedWeek = chooseInitialWeek(weeks);
+      if(!selectedWeek) throw new Error('Could not resolve a selected week from the index sheet.');
+
+      sourceUrl = selectedWeek.url || null;
+      if(!sourceUrl && selectedWeek.gid != null){
+        sourceUrl = csvUrlForGid(selectedWeek.gid);
+      }
+      if(!sourceUrl){
+        throw new Error('Selected week is missing both URL and gid source references.');
+      }
     }
 
-    const selectedWeek = chooseInitialWeek(weeks);
-    if(!selectedWeek) throw new Error('Could not resolve a selected week from the index sheet.');
-
-    let sourceUrl = selectedWeek.url || null;
-    if(!sourceUrl && selectedWeek.gid != null){
-      sourceUrl = csvUrlForGid(selectedWeek.gid);
-    }
-    if(!sourceUrl){
-      throw new Error('Selected week is missing both URL and gid source references.');
-    }
-
-    const res = await fetch(sourceUrl, { cache: 'no-store' });
+    const finalUrl = bust ? withBust(sourceUrl) : sourceUrl;
+    const res = await fetch(finalUrl, { cache: bust ? 'reload' : 'no-store' });
     if(!res.ok){
-      throw new Error(`MaintainX week load failed (${res.status} ${res.statusText})`);
+      const sourceLabel = sourceType === 'raw_work_orders' ? 'MX_Raw_WorkOrders' : 'MaintainX week';
+      throw new Error(`${sourceLabel} load failed (${res.status} ${res.statusText})`);
     }
 
     const text = await res.text();
     if(!text || !text.trim()){
-      throw new Error('MaintainX week CSV is empty.');
+      const sourceLabel = sourceType === 'raw_work_orders' ? 'MX_Raw_WorkOrders' : 'MaintainX week CSV';
+      throw new Error(`${sourceLabel} is empty.`);
     }
 
     const parsed = parseDelimited(text);
     const dedupedRows = dedupeRows(parsed.rows || []);
 
     return {
+      sourceType,
+      sourceUrl,
       selectedWeek,
       headers: parsed.headers || [],
       rawRows: dedupedRows
@@ -470,6 +488,8 @@
 
     return {
       ...grouped,
+      sourceType: source.sourceType,
+      sourceUrl: source.sourceUrl,
       selectedWeek: source.selectedWeek,
       summary: {
         ...grouped.summary,
@@ -482,6 +502,8 @@
 
   const api = {
     SHEET_INDEX_CSV_URL,
+    RAW_WORK_ORDERS_CSV_URL,
+    MAINTAINX_SOURCE_CONFIG,
     SITE_KEY_LABELS,
     loadMaintainXRawData,
     getNormalizedWorkOrders,

--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -327,6 +327,11 @@
       const root = document.body;
 
       let selectedSiteKey = 'all';
+      const MAINTAINX_SOURCE_CONFIG = Object.freeze({
+        ...window.PPMWeeklyAssetTransform.MAINTAINX_SOURCE_CONFIG,
+        sourceMode: 'selected_week'
+      });
+
       let plannerData = null;
       let plannerError = null;
 
@@ -449,7 +454,9 @@
         document.querySelector('[data-kpi="week1-work-orders"]').textContent = String(totalWeek1);
 
         const rowsMarkup = grouped.rows.map(PPMAssetRow).join('');
-        const selectedWeekLabel = plannerData.selectedWeek?.label || plannerData.selectedWeek?.weekEnd || 'latest published week';
+        const selectedWeekLabel = plannerData.sourceType === 'raw_work_orders'
+          ? 'MX_Raw_WorkOrders'
+          : (plannerData.selectedWeek?.label || plannerData.selectedWeek?.weekEnd || 'latest published week');
         const emptyMarkup = grouped.rows.length === 0
           ? `<p class="empty-state">No active PPM work orders found for the selected site and 3-week period (source: ${selectedWeekLabel}).</p>`
           : '';
@@ -459,11 +466,13 @@
 
       async function loadPlannerData(){
         try {
-          const source = await window.PPMWeeklyAssetTransform.loadMaintainXRawData();
+          const source = await window.PPMWeeklyAssetTransform.loadMaintainXRawData(MAINTAINX_SOURCE_CONFIG);
           const normalized = window.PPMWeeklyAssetTransform.getNormalizedWorkOrders(source.rawRows);
           const activePPM = window.PPMWeeklyAssetTransform.getActivePPMWorkOrders(normalized);
 
           plannerData = {
+            sourceType: source.sourceType,
+            sourceUrl: source.sourceUrl,
             selectedWeek: source.selectedWeek,
             activePPM
           };


### PR DESCRIPTION
### Motivation
- Allow the weekly-asset transform to load either the index-selected week tab or the full `MX_Raw_WorkOrders` sheet via a single explicit switch so callers can choose the source used for enrichment and diagnostics. 
- Preserve exact source provenance in returned payloads so the UI and logs can show which sheet/URL and week were used. 

### Description
- Introduced `RAW_WORK_ORDERS_CSV_URL` and an exported config `MAINTAINX_SOURCE_CONFIG` (with `sourceMode`) in `ppm-weekly-asset-transform.js` to centralize the source-mode default. 
- Refactored `loadMaintainXRawData` to accept `sourceMode` (defaults to `MAINTAINX_SOURCE_CONFIG.sourceMode`) and select between `selected_week` (index-driven tab via `gid/url`) and `raw_work_orders` (`MX_Raw_WorkOrders`) while keeping a single fetch/parse/dedupe flow. 
- Extended the source payload returned by `loadMaintainXRawData` to include `sourceType`, `sourceUrl`, and `selectedWeek`, and propagated `sourceType`/`sourceUrl` through `buildPPMPlannerModelFromMaintainX` so downstream consumers receive provenance. 
- Updated `ppm-weekly-asset.html` to build a local `MAINTAINX_SOURCE_CONFIG` from the exported default and pass it to `loadMaintainXRawData`, to persist `sourceType`/`sourceUrl` into `plannerData`, and to adapt the empty-state source label to reflect the selected source. 

### Testing
- Ran `node --check ppm-weekly-asset-transform.js` to validate the transformed JS syntax, which succeeded. 
- Attempted `node --check ppm-weekly-asset.html` but Node does not support syntax-checking `.html` files directly, so no syntactic HTML check was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08d5b41c48326bdc5e61a48126fb8)