### PR TITLE
Add staged PPM filters and completed-status toggle to weekly asset planner

### DIFF
--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -28,6 +28,11 @@
     'done',
     'rejected'
   ];
+  const DONE_STATUS_TOKENS = ['complete', 'completed', 'done'];
+  const PPM_STATUS_MODES = Object.freeze({
+    ACTIVE_ONLY: 'active_only',
+    INCLUDE_DONE: 'include_done'
+  });
 
   const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -323,21 +328,82 @@
     return parts.some(part => /\bppm\b/i.test(part));
   }
 
-  function isActivePlanningStatus(status){
+  function isActivePlanningStatus(status, statusMode = PPM_STATUS_MODES.ACTIVE_ONLY){
     const normalized = normalizeKey(status);
     if(!normalized) return false;
-    if(INACTIVE_STATUS_BLOCKLIST.some(token => normalized.includes(token))) return false;
+    const includeDone = statusMode === PPM_STATUS_MODES.INCLUDE_DONE;
+    if(INACTIVE_STATUS_BLOCKLIST.some((token) => {
+      if(includeDone && DONE_STATUS_TOKENS.includes(token)) return false;
+      return normalized.includes(token);
+    })) return false;
     return ACTIVE_STATUS_ALLOWLIST.some(token => normalized.includes(token));
   }
 
-  function getActivePPMWorkOrders(workOrders){
-    return (Array.isArray(workOrders) ? workOrders : []).filter(order => {
-      if(!isPPMCategory(order.category)) return false;
-      if(!isActivePlanningStatus(order.status)) return false;
-      if(!order.assetName) return false;
-      if(!order.woNumber) return false;
-      return true;
-    });
+  function filterCategoryPPM(workOrders){
+    const inputRows = Array.isArray(workOrders) ? workOrders : [];
+    const kept = [];
+    const excluded = [];
+    for(const order of inputRows){
+      if(isPPMCategory(order.category)){
+        kept.push(order);
+      } else {
+        excluded.push({ reason: 'non_ppm_category', order });
+      }
+    }
+    return { kept, excluded, counters: { input: inputRows.length, kept: kept.length, excluded: excluded.length } };
+  }
+
+  function filterStatus(workOrders, { statusMode = PPM_STATUS_MODES.ACTIVE_ONLY } = {}){
+    const inputRows = Array.isArray(workOrders) ? workOrders : [];
+    const kept = [];
+    const excluded = [];
+    for(const order of inputRows){
+      if(isActivePlanningStatus(order.status, statusMode)){
+        kept.push(order);
+      } else {
+        const statusRaw = toStringSafe(order.status);
+        console.info('[PPM Weekly Asset] Excluded row', { reason: 'inactive_status', status: statusRaw, id: order.woNumber || order.id || null });
+        excluded.push({ reason: 'inactive_status', status: statusRaw, order });
+      }
+    }
+    return { kept, excluded, counters: { input: inputRows.length, kept: kept.length, excluded: excluded.length } };
+  }
+
+  function filterHasAsset(workOrders){
+    const inputRows = Array.isArray(workOrders) ? workOrders : [];
+    const kept = [];
+    const excluded = [];
+    for(const order of inputRows){
+      if(order.assetName){
+        kept.push(order);
+      } else {
+        excluded.push({ reason: 'missing_asset', order });
+      }
+    }
+    return { kept, excluded, counters: { input: inputRows.length, kept: kept.length, excluded: excluded.length } };
+  }
+
+  function filterHasId(workOrders){
+    const inputRows = Array.isArray(workOrders) ? workOrders : [];
+    const kept = [];
+    const excluded = [];
+    for(const order of inputRows){
+      if(order.woNumber){
+        kept.push(order);
+      } else {
+        excluded.push({ reason: 'missing_id', order });
+      }
+    }
+    return { kept, excluded, counters: { input: inputRows.length, kept: kept.length, excluded: excluded.length } };
+  }
+
+  function getActivePPMWorkOrders(workOrders, { statusMode = PPM_STATUS_MODES.ACTIVE_ONLY } = {}){
+    const stageCategory = filterCategoryPPM(workOrders);
+    const stageStatus = filterStatus(stageCategory.kept, { statusMode });
+    const stageAsset = filterHasAsset(stageStatus.kept);
+    const stageId = filterHasId(stageAsset.kept);
+
+    return stageId.kept;
   }
 
   function computeWeekBucket(date, selectedPeriodStart){
@@ -464,7 +530,7 @@
   async function buildPPMPlannerModelFromMaintainX(options = {}){
     const source = await loadMaintainXRawData(options);
     const normalized = getNormalizedWorkOrders(source.rawRows);
-    const activePPM = getActivePPMWorkOrders(normalized);
+    const activePPM = getActivePPMWorkOrders(normalized, { statusMode: options.statusMode || PPM_STATUS_MODES.ACTIVE_ONLY });
     const selectedPeriodStart = options.selectedPeriodStart || startOfWeek(new Date());
     const grouped = groupPPMWorkOrdersByAssetAndWeek(activePPM, options.siteKey || 'all', selectedPeriodStart);
 
@@ -487,10 +553,15 @@
     getNormalizedWorkOrders,
     getActivePPMWorkOrders,
     groupPPMWorkOrdersByAssetAndWeek,
+    filterCategoryPPM,
+    filterStatus,
+    filterHasAsset,
+    filterHasId,
+    PPM_STATUS_MODES,
     buildPPMPlannerModelFromMaintainX,
-    buildPPMPlannerModel(rawRows, { siteKey = 'all', selectedPeriodStart } = {}){
+    buildPPMPlannerModel(rawRows, { siteKey = 'all', selectedPeriodStart, statusMode = PPM_STATUS_MODES.ACTIVE_ONLY } = {}){
       const normalized = getNormalizedWorkOrders(rawRows);
-      const activePPM = getActivePPMWorkOrders(normalized);
+      const activePPM = getActivePPMWorkOrders(normalized, { statusMode });
       const grouped = groupPPMWorkOrdersByAssetAndWeek(activePPM, siteKey, selectedPeriodStart || startOfWeek(new Date()));
       return {
         ...grouped,

--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -332,11 +332,14 @@
     const normalized = normalizeKey(status);
     if(!normalized) return false;
     const includeDone = statusMode === PPM_STATUS_MODES.INCLUDE_DONE;
+    const hasDoneStatus = DONE_STATUS_TOKENS.some(token => normalized.includes(token));
+    const hasActiveStatus = ACTIVE_STATUS_ALLOWLIST.some(token => normalized.includes(token));
     if(INACTIVE_STATUS_BLOCKLIST.some((token) => {
       if(includeDone && DONE_STATUS_TOKENS.includes(token)) return false;
       return normalized.includes(token);
     })) return false;
-    return ACTIVE_STATUS_ALLOWLIST.some(token => normalized.includes(token));
+    if(includeDone) return hasDoneStatus || hasActiveStatus;
+    return hasActiveStatus;
   }
 
   function filterCategoryPPM(workOrders){

--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -139,6 +139,8 @@
       cursor:pointer;
     }
     .site-filter__tab[aria-pressed="true"] { border-color:var(--als-blue); background:color-mix(in srgb,var(--als-blue) 12%,var(--paper)); }
+    .status-mode-toggle { display:inline-flex; align-items:center; gap:6px; font-weight:600; color:var(--muted); }
+    .status-mode-toggle input { accent-color:var(--als-blue); }
 
     .kpi-row { display:grid; grid-template-columns:repeat(3,minmax(180px,1fr)); gap:12px; margin:0 0 20px; }
     .kpi-card {
@@ -294,12 +296,16 @@
             <button type="button" class="site-filter__tab" data-site-key="Byron" aria-pressed="false">Byron</button>
           </div>
         </div>
+        <label class="status-mode-toggle" title="Include completed PPM work orders in planner totals">
+          <input type="checkbox" data-role="status-mode-toggle" />
+          Include completed PPMs
+        </label>
       </div>
     </section>
 
     <section class="kpi-row" aria-label="PPM summary KPIs">
       <article class="kpi-card">
-        <div class="kpi-card__label">Active PPM Work Orders</div>
+        <div class="kpi-card__label" data-role="kpi-total-label">Active PPM Work Orders</div>
         <div class="kpi-card__value" data-kpi="total-work-orders">0</div>
       </article>
       <article class="kpi-card">
@@ -323,10 +329,13 @@
       const plannerSurface = document.querySelector('[data-role="planner-surface"]');
       const siteLabel = document.querySelector('[data-role="site-filter-active"]');
       const siteFilterTabs = document.querySelector('.site-filter__tabs');
+      const statusModeToggle = document.querySelector('[data-role="status-mode-toggle"]');
+      const kpiTotalLabel = document.querySelector('[data-role="kpi-total-label"]');
       const themeBtn = document.getElementById('dark-toggle');
       const root = document.body;
 
       let selectedSiteKey = 'all';
+      let statusMode = window.PPMWeeklyAssetTransform.PPM_STATUS_MODES.ACTIVE_ONLY;
       let plannerData = null;
       let plannerError = null;
 
@@ -438,20 +447,28 @@
         }
 
         const grouped = window.PPMWeeklyAssetTransform.groupPPMWorkOrdersByAssetAndWeek(
-          plannerData.activePPM,
+          plannerData.filteredPPM,
           selectedSiteKey,
           startOfWeek(new Date())
         );
 
         const totalWeek1 = grouped.rows.reduce((acc, row) => acc + row.weeks.week1.length, 0);
+        if(kpiTotalLabel){
+          kpiTotalLabel.textContent = statusMode === window.PPMWeeklyAssetTransform.PPM_STATUS_MODES.INCLUDE_DONE
+            ? 'PPM Work Orders (Including Completed)'
+            : 'Active PPM Work Orders';
+        }
         document.querySelector('[data-kpi="total-work-orders"]').textContent = String(grouped.summary.totalWorkOrders);
         document.querySelector('[data-kpi="total-assets"]').textContent = String(grouped.summary.totalAssets);
         document.querySelector('[data-kpi="week1-work-orders"]').textContent = String(totalWeek1);
 
         const rowsMarkup = grouped.rows.map(PPMAssetRow).join('');
         const selectedWeekLabel = plannerData.selectedWeek?.label || plannerData.selectedWeek?.weekEnd || 'latest published week';
+        const statusPhrase = statusMode === window.PPMWeeklyAssetTransform.PPM_STATUS_MODES.INCLUDE_DONE
+          ? 'PPM work orders'
+          : 'active PPM work orders';
         const emptyMarkup = grouped.rows.length === 0
-          ? `<p class="empty-state">No active PPM work orders found for the selected site and 3-week period (source: ${selectedWeekLabel}).</p>`
+          ? `<p class="empty-state">No ${statusPhrase} found for the selected site and 3-week period (source: ${selectedWeekLabel}).</p>`
           : '';
 
         plannerSurface.innerHTML = `${PPMPlannerHeader()}${rowsMarkup}${emptyMarkup}`;
@@ -461,15 +478,15 @@
         try {
           const source = await window.PPMWeeklyAssetTransform.loadMaintainXRawData();
           const normalized = window.PPMWeeklyAssetTransform.getNormalizedWorkOrders(source.rawRows);
-          const activePPM = window.PPMWeeklyAssetTransform.getActivePPMWorkOrders(normalized);
+          const filteredPPM = window.PPMWeeklyAssetTransform.getActivePPMWorkOrders(normalized, { statusMode });
 
           plannerData = {
             selectedWeek: source.selectedWeek,
-            activePPM
+            filteredPPM
           };
 
           const initialGroup = window.PPMWeeklyAssetTransform.groupPPMWorkOrdersByAssetAndWeek(
-            activePPM,
+            filteredPPM,
             'all',
             startOfWeek(new Date())
           );
@@ -509,6 +526,12 @@
 
       renderSiteFilter([]);
       renderPlanner();
+      statusModeToggle?.addEventListener('change', () => {
+        statusMode = statusModeToggle.checked
+          ? window.PPMWeeklyAssetTransform.PPM_STATUS_MODES.INCLUDE_DONE
+          : window.PPMWeeklyAssetTransform.PPM_STATUS_MODES.ACTIVE_ONLY;
+        loadPlannerData();
+      });
       loadPlannerData();
       updateStickyOffset();
       window.addEventListener('resize', updateStickyOffset, { passive:true });


### PR DESCRIPTION
### Motivation
- Make PPM filtering more explicit and observable by splitting it into named stages with counters so operators can understand what rows are being dropped. 
- Provide a planner-facing option to include completed/done PPM work orders for reconciliation of expected totals. 

### Description
- Introduced `PPM_STATUS_MODES` (`active_only` default, `include_done`) and `DONE_STATUS_TOKENS` and threaded `statusMode` through model builders so status filtering can be toggled. 
- Split filtering into staged helpers `filterCategoryPPM`, `filterStatus`, `filterHasAsset`, and `filterHasId`, each returning kept/excluded lists and counters, and updated `getActivePPMWorkOrders` to run the stages in order. 
- Updated status filtering to log excluded rows with `{ reason: 'inactive_status', status: <raw status>, id: <id> }` when rows are dropped for inactive status, and adjusted logic so `include_done` keeps completed/done tokens while still excluding other inactive statuses. 
- Exposed the new staged filters and `PPM_STATUS_MODES` on the transform API and added a checkbox in `ppm-weekly-asset.html` to toggle inclusion of completed PPMs; the UI reloads planner data and updates KPI/empty-state copy based on the selected mode. 

### Testing
- Ran `node --check ppm-weekly-asset-transform.js` to validate JavaScript syntax and it succeeded. 
- Attempted `node --check ppm-weekly-asset.html` but Node cannot syntax-check `.html` files (unknown file extension), so no HTML-specific automated check was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08d6fbd5c83269dea921b8ba468b3)