### PR TITLE
Add diagnostics and improve period anchoring for weekly PPM planner

### DIFF
--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -361,19 +361,57 @@
     return 'outOfRange';
   }
 
+  function classifyDueDate(date, selectedPeriodStart){
+    const workDate = startOfDay(parseDateValue(date));
+    const periodStart = startOfDay(parseDateValue(selectedPeriodStart));
+    if(!workDate || !periodStart){
+      return { bucket: 'outOfRange', deltaDays: null };
+    }
+    const deltaMs = workDate.getTime() - periodStart.getTime();
+    const deltaDays = Math.floor(deltaMs / (24 * 60 * 60 * 1000));
+    return {
+      bucket: computeWeekBucket(workDate, periodStart),
+      deltaDays
+    };
+  }
+
   function createEmptyWeeks(){
     return { week1: [], week2: [], week3: [] };
+  }
+
+  function formatDateISO(date){
+    const parsed = startOfDay(parseDateValue(date));
+    if(!parsed) return 'n/a';
+    const y = parsed.getFullYear();
+    const m = String(parsed.getMonth() + 1).padStart(2, '0');
+    const d = String(parsed.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
   }
 
   function groupPPMWorkOrdersByAssetAndWeek(workOrders, selectedSite, selectedPeriodStart){
     const filteredSiteKey = selectedSite && selectedSite !== 'all' ? selectedSite : 'all';
     const bySite = new Map();
+    const diagnostics = {
+      bucketed: { week1: 0, week2: 0, week3: 0 },
+      excluded: { outOfRange: 0, outOfRangeWorkOrders: [] }
+    };
 
     for(const order of (Array.isArray(workOrders) ? workOrders : [])){
       if(filteredSiteKey !== 'all' && order.siteKey !== filteredSiteKey) continue;
 
-      const bucket = computeWeekBucket(order.dueDate || order.dueDateRaw, selectedPeriodStart);
-      if(bucket === 'outOfRange') continue;
+      const dueDateInput = order.dueDate || order.dueDateRaw;
+      const classification = classifyDueDate(dueDateInput, selectedPeriodStart);
+      const bucket = classification.bucket;
+      if(bucket === 'outOfRange'){
+        diagnostics.excluded.outOfRange += 1;
+        diagnostics.excluded.outOfRangeWorkOrders.push({
+          id: order.woNumber || order.id || '',
+          dueDate: formatDateISO(order.dueDate || order.dueDateRaw),
+          deltaDays: classification.deltaDays
+        });
+        continue;
+      }
+      diagnostics.bucketed[bucket] += 1;
 
       const siteKey = order.siteKey || 'other';
       if(!bySite.has(siteKey)) bySite.set(siteKey, new Map());
@@ -420,7 +458,8 @@
       summary: {
         totalAssets,
         totalWorkOrders
-      }
+      },
+      diagnostics
     };
   }
 
@@ -465,7 +504,8 @@
     const source = await loadMaintainXRawData(options);
     const normalized = getNormalizedWorkOrders(source.rawRows);
     const activePPM = getActivePPMWorkOrders(normalized);
-    const selectedPeriodStart = options.selectedPeriodStart || startOfWeek(new Date());
+    const selectedPeriodAnchor = options.selectedPeriodStart || source.selectedWeek?.weekEnd || new Date();
+    const selectedPeriodStart = startOfWeek(selectedPeriodAnchor);
     const grouped = groupPPMWorkOrdersByAssetAndWeek(activePPM, options.siteKey || 'all', selectedPeriodStart);
 
     return {
@@ -491,7 +531,7 @@
     buildPPMPlannerModel(rawRows, { siteKey = 'all', selectedPeriodStart } = {}){
       const normalized = getNormalizedWorkOrders(rawRows);
       const activePPM = getActivePPMWorkOrders(normalized);
-      const grouped = groupPPMWorkOrdersByAssetAndWeek(activePPM, siteKey, selectedPeriodStart || startOfWeek(new Date()));
+      const grouped = groupPPMWorkOrdersByAssetAndWeek(activePPM, siteKey, startOfWeek(selectedPeriodStart || new Date()));
       return {
         ...grouped,
         summary: {

--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -150,6 +150,32 @@
     }
     .kpi-card__label { color:var(--muted); font-size:12px; font-weight:600; }
     .kpi-card__value { margin-top:4px; font-size:24px; font-weight:800; }
+    .diagnostics-panel {
+      margin:0 0 16px;
+      padding:10px 12px;
+      border:1px solid var(--grid);
+      border-radius:10px;
+      background:var(--paper);
+      color:var(--muted);
+      font-size:12px;
+      line-height:1.45;
+      box-shadow:var(--shadow);
+    }
+    .diagnostics-panel__title {
+      color:var(--ink);
+      font-weight:700;
+      margin:0 0 4px;
+    }
+    .diagnostics-panel__meta {
+      margin:0;
+    }
+    .diagnostics-panel__list {
+      margin:8px 0 0;
+      padding:0 0 0 18px;
+      max-height:160px;
+      overflow:auto;
+    }
+    .diagnostics-panel__list li { margin:2px 0; }
 
     .planner {
       border:1px solid var(--grid);
@@ -311,6 +337,7 @@
         <div class="kpi-card__value" data-kpi="week1-work-orders">0</div>
       </article>
     </section>
+    <section class="diagnostics-panel" aria-live="polite" data-role="diagnostics-panel"></section>
 
     <section class="planner" aria-label="Weekly PPM planning matrix">
       <div class="planner__surface" data-role="planner-surface"></div>
@@ -321,6 +348,7 @@
   <script>
     (function(){
       const plannerSurface = document.querySelector('[data-role="planner-surface"]');
+      const diagnosticsPanel = document.querySelector('[data-role="diagnostics-panel"]');
       const siteLabel = document.querySelector('[data-role="site-filter-active"]');
       const siteFilterTabs = document.querySelector('.site-filter__tabs');
       const themeBtn = document.getElementById('dark-toggle');
@@ -337,6 +365,10 @@
         d.setDate(d.getDate() - mondayOffset);
         d.setHours(0, 0, 0, 0);
         return d;
+      }
+
+      function getPeriodAnchorFromSelectedWeek(selectedWeek){
+        return selectedWeek?.weekEnd || new Date();
       }
 
       function cardStatusClass(status){
@@ -421,6 +453,9 @@
 
       function renderError(message){
         plannerSurface.innerHTML = `${PPMPlannerHeader()}<p class="empty-state">${message}</p>`;
+        if(diagnosticsPanel){
+          diagnosticsPanel.innerHTML = '<p class="diagnostics-panel__title">Diagnostics</p><p class="diagnostics-panel__meta">Unavailable while planner data is loading.</p>';
+        }
         document.querySelector('[data-kpi="total-work-orders"]').textContent = '0';
         document.querySelector('[data-kpi="total-assets"]').textContent = '0';
         document.querySelector('[data-kpi="week1-work-orders"]').textContent = '0';
@@ -437,16 +472,18 @@
           return;
         }
 
+        const selectedPeriodStart = startOfWeek(getPeriodAnchorFromSelectedWeek(plannerData.selectedWeek));
         const grouped = window.PPMWeeklyAssetTransform.groupPPMWorkOrdersByAssetAndWeek(
           plannerData.activePPM,
           selectedSiteKey,
-          startOfWeek(new Date())
+          selectedPeriodStart
         );
 
         const totalWeek1 = grouped.rows.reduce((acc, row) => acc + row.weeks.week1.length, 0);
         document.querySelector('[data-kpi="total-work-orders"]').textContent = String(grouped.summary.totalWorkOrders);
         document.querySelector('[data-kpi="total-assets"]').textContent = String(grouped.summary.totalAssets);
         document.querySelector('[data-kpi="week1-work-orders"]').textContent = String(totalWeek1);
+        renderDiagnostics(grouped.diagnostics);
 
         const rowsMarkup = grouped.rows.map(PPMAssetRow).join('');
         const selectedWeekLabel = plannerData.selectedWeek?.label || plannerData.selectedWeek?.weekEnd || 'latest published week';
@@ -455,6 +492,28 @@
           : '';
 
         plannerSurface.innerHTML = `${PPMPlannerHeader()}${rowsMarkup}${emptyMarkup}`;
+      }
+
+      function renderDiagnostics(diagnostics){
+        if(!diagnosticsPanel) return;
+        const bucketed = diagnostics?.bucketed || {};
+        const excluded = diagnostics?.excluded || {};
+        const excludedRows = Array.isArray(excluded?.outOfRangeWorkOrders)
+          ? excluded.outOfRangeWorkOrders
+          : (Array.isArray(diagnostics?.excludedWorkOrders) ? diagnostics.excludedWorkOrders : []);
+        const detailItems = excludedRows.slice(0, 8).map((row) => {
+          const delta = Number.isFinite(row.deltaDays) ? `${row.deltaDays}d` : 'n/a';
+          return `<li>${row.id || 'Unknown'} • due ${row.dueDate || 'n/a'} • Δ ${delta}</li>`;
+        }).join('');
+        const remainingCount = Math.max(excludedRows.length - 8, 0);
+        const remainingMarkup = remainingCount > 0 ? `<li>+${remainingCount} more excluded</li>` : '';
+
+        diagnosticsPanel.innerHTML = `
+          <p class="diagnostics-panel__title">Diagnostics</p>
+          <p class="diagnostics-panel__meta">Bucketed — W1: ${bucketed.week1 || 0}, W2: ${bucketed.week2 || 0}, W3: ${bucketed.week3 || 0}.</p>
+          <p class="diagnostics-panel__meta">Excluded (out of 3-week range): ${excluded.outOfRange || 0}.</p>
+          ${excludedRows.length ? `<ol class="diagnostics-panel__list">${detailItems}${remainingMarkup}</ol>` : ''}
+        `;
       }
 
       async function loadPlannerData(){
@@ -468,10 +527,11 @@
             activePPM
           };
 
+          const selectedPeriodStart = startOfWeek(getPeriodAnchorFromSelectedWeek(source.selectedWeek));
           const initialGroup = window.PPMWeeklyAssetTransform.groupPPMWorkOrdersByAssetAndWeek(
             activePPM,
             'all',
-            startOfWeek(new Date())
+            selectedPeriodStart
           );
 
           renderSiteFilter(initialGroup.sites);


### PR DESCRIPTION
### Motivation
- Provide visibility into work orders excluded from the 3-week window and improve reliability of week bucketing by explicitly classifying due dates and using the selected week anchor as the period start.
- Make planner behavior deterministic when a selected week is provided so the UI and API use the same reference date for week calculations.

### Description
- Add `classifyDueDate` and `formatDateISO` helpers and replace direct `computeWeekBucket` calls with classification that returns both a `bucket` and `deltaDays` for diagnostics. 
- Extend `groupPPMWorkOrdersByAssetAndWeek` to accumulate `diagnostics` (counts per week and excluded out-of-range rows) and to record a small sample of excluded work orders with IDs, ISO dates, and day deltas. 
- Use the selected week `weekEnd` as the period anchor in `buildPPMPlannerModelFromMaintainX` and the public `buildPPMPlannerModel` API so `selectedPeriodStart` is computed as `startOfWeek(selectedWeek.weekEnd)` when available. 
- Add a diagnostics panel to the HTML (`.diagnostics-panel`) and client-side renderer functions `renderDiagnostics`, `getPeriodAnchorFromSelectedWeek`, and related wiring so the UI shows bucket counts and a short list of excluded work orders; update error/loading rendering to include diagnostics state. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08da8342c83268a778af37060b2c6)