### PR TITLE
Add PPM pipeline diagnostics and debug panel

### DIFF
--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -347,12 +347,12 @@
     const excludedRows = [];
 
     const EXCLUSION_REASONS = Object.freeze({
-      NOT_PPM: 'Not a PPM category',
-      MISSING_WO: 'Missing WO number',
-      MISSING_ASSET: 'Missing asset',
-      INACTIVE_STATUS: 'Inactive status',
-      FILTERED_BY_SITE: 'Filtered out by selected site',
-      OUT_OF_RANGE: 'Due date is outside selected 3-week window'
+      NOT_PPM: { code: 'not_ppm_category', label: 'Not a PPM category' },
+      MISSING_WO: { code: 'missing_wo_number', label: 'Missing WO number' },
+      MISSING_ASSET: { code: 'missing_asset', label: 'Missing asset' },
+      INACTIVE_STATUS: { code: 'inactive_status', label: 'Inactive status' },
+      FILTERED_BY_SITE: { code: 'filtered_by_site', label: 'Filtered out by selected site' },
+      OUT_OF_RANGE: { code: 'due_date_out_of_range', label: 'Due date is outside selected 3-week window' }
     });
 
     const toExcluded = (row, exclusionReason) => ({
@@ -363,7 +363,8 @@
       rawAsset: row.assetName || '',
       rawStatus: row.status || '',
       rawDueDate: row.dueDateRaw || '',
-      exclusionReason
+      exclusionReason: exclusionReason.label,
+      exclusionReasonCode: exclusionReason.code
     });
 
     const ppmMatches = [];

--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -340,6 +340,109 @@
     });
   }
 
+  function buildPPMPipelineDiagnostics(rawRows, options = {}){
+    const selectedSite = options.siteKey || 'all';
+    const selectedPeriodStart = options.selectedPeriodStart || startOfWeek(new Date());
+    const normalizedRows = getNormalizedWorkOrders(rawRows);
+    const excludedRows = [];
+
+    const EXCLUSION_REASONS = Object.freeze({
+      NOT_PPM: 'Not a PPM category',
+      MISSING_WO: 'Missing WO number',
+      MISSING_ASSET: 'Missing asset',
+      INACTIVE_STATUS: 'Inactive status',
+      FILTERED_BY_SITE: 'Filtered out by selected site',
+      OUT_OF_RANGE: 'Due date is outside selected 3-week window'
+    });
+
+    const toExcluded = (row, exclusionReason) => ({
+      woNumber: row.woNumber || '',
+      title: row.title || '',
+      rawCategory: row.category || '',
+      rawSite: row.site || '',
+      rawAsset: row.assetName || '',
+      rawStatus: row.status || '',
+      rawDueDate: row.dueDateRaw || '',
+      exclusionReason
+    });
+
+    const ppmMatches = [];
+    for(const row of normalizedRows){
+      if(isPPMCategory(row.category)){
+        ppmMatches.push(row);
+      } else {
+        excludedRows.push(toExcluded(row, EXCLUSION_REASONS.NOT_PPM));
+      }
+    }
+
+    const validAssetRows = [];
+    for(const row of ppmMatches){
+      if(!row.woNumber){
+        excludedRows.push(toExcluded(row, EXCLUSION_REASONS.MISSING_WO));
+        continue;
+      }
+      if(!row.assetName){
+        excludedRows.push(toExcluded(row, EXCLUSION_REASONS.MISSING_ASSET));
+        continue;
+      }
+      validAssetRows.push(row);
+    }
+
+    const activeRows = [];
+    const inactiveRows = [];
+    for(const row of validAssetRows){
+      if(isActivePlanningStatus(row.status)){
+        activeRows.push(row);
+      } else {
+        inactiveRows.push(row);
+        excludedRows.push(toExcluded(row, EXCLUSION_REASONS.INACTIVE_STATUS));
+      }
+    }
+
+    const selectedSiteRows = [];
+    for(const row of activeRows){
+      if(selectedSite !== 'all' && row.siteKey !== selectedSite){
+        excludedRows.push(toExcluded(row, EXCLUSION_REASONS.FILTERED_BY_SITE));
+        continue;
+      }
+      selectedSiteRows.push(row);
+    }
+
+    let week1Count = 0;
+    let week2Count = 0;
+    let week3Count = 0;
+    for(const row of selectedSiteRows){
+      const bucket = computeWeekBucket(row.dueDate || row.dueDateRaw, selectedPeriodStart);
+      if(bucket === 'week1'){
+        week1Count += 1;
+      } else if(bucket === 'week2'){
+        week2Count += 1;
+      } else if(bucket === 'week3'){
+        week3Count += 1;
+      } else {
+        excludedRows.push(toExcluded(row, EXCLUSION_REASONS.OUT_OF_RANGE));
+      }
+    }
+
+    const finalRenderedCardCount = week1Count + week2Count + week3Count;
+    const validAssetCount = validAssetRows.length;
+
+    return {
+      totalRawRowsLoaded: Array.isArray(rawRows) ? rawRows.length : 0,
+      parsedNormalizedRows: normalizedRows.length,
+      ppmCategoryMatches: ppmMatches.length,
+      validAssetCount,
+      activeCount: activeRows.length,
+      inactiveCount: inactiveRows.length,
+      selectedSiteSurvivors: selectedSiteRows.length,
+      week1Count,
+      week2Count,
+      week3Count,
+      finalRenderedCardCount,
+      excludedRows
+    };
+  }
+
   function computeWeekBucket(date, selectedPeriodStart){
     const workDate = startOfDay(parseDateValue(date));
     const periodStart = startOfDay(parseDateValue(selectedPeriodStart));
@@ -488,6 +591,7 @@
     getActivePPMWorkOrders,
     groupPPMWorkOrdersByAssetAndWeek,
     buildPPMPlannerModelFromMaintainX,
+    buildPPMPipelineDiagnostics,
     buildPPMPlannerModel(rawRows, { siteKey = 'all', selectedPeriodStart } = {}){
       const normalized = getNormalizedWorkOrders(rawRows);
       const activePPM = getActivePPMWorkOrders(normalized);

--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -258,6 +258,43 @@
 
     .planner-row:last-child .planner-cell { border-bottom:none; }
 
+    .debug-panel {
+      margin-top:18px;
+      border:1px solid var(--grid);
+      border-radius:12px;
+      background:var(--paper);
+      box-shadow:var(--shadow);
+      overflow:auto;
+      display:none;
+    }
+    .debug-panel[data-visible="true"] { display:block; }
+    .debug-panel__head {
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+      gap:12px;
+      padding:10px 12px;
+      border-bottom:1px solid var(--grid);
+      font-weight:700;
+    }
+    .debug-table {
+      width:100%;
+      border-collapse:collapse;
+      font-size:12px;
+    }
+    .debug-table th,
+    .debug-table td {
+      border-bottom:1px solid var(--grid);
+      border-right:1px solid var(--grid);
+      padding:6px 8px;
+      text-align:left;
+      vertical-align:top;
+      white-space:nowrap;
+    }
+    .debug-table th:last-child,
+    .debug-table td:last-child { border-right:none; }
+    .debug-table tr:last-child td { border-bottom:none; }
+
     @media (max-width: 820px){
       .kpi-row{grid-template-columns:1fr;}
       .logo{display:none;}
@@ -315,6 +352,28 @@
     <section class="planner" aria-label="Weekly PPM planning matrix">
       <div class="planner__surface" data-role="planner-surface"></div>
     </section>
+
+    <section class="debug-panel" data-role="debug-panel" aria-label="PPM diagnostics">
+      <div class="debug-panel__head">
+        <span>Developer diagnostics (excluded PPM rows)</span>
+        <span data-role="debug-summary">No rows</span>
+      </div>
+      <table class="debug-table">
+        <thead>
+          <tr>
+            <th>WO</th>
+            <th>Title</th>
+            <th>Category</th>
+            <th>Site</th>
+            <th>Asset</th>
+            <th>Status</th>
+            <th>Due date</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody data-role="debug-body"></tbody>
+      </table>
+    </section>
   </div>
 
   <script src="ppm-weekly-asset-transform.js"></script>
@@ -324,11 +383,16 @@
       const siteLabel = document.querySelector('[data-role="site-filter-active"]');
       const siteFilterTabs = document.querySelector('.site-filter__tabs');
       const themeBtn = document.getElementById('dark-toggle');
+      const debugPanel = document.querySelector('[data-role="debug-panel"]');
+      const debugBody = document.querySelector('[data-role="debug-body"]');
+      const debugSummary = document.querySelector('[data-role="debug-summary"]');
       const root = document.body;
+      const debugMode = new URLSearchParams(window.location.search).get('debug') === '1';
 
       let selectedSiteKey = 'all';
       let plannerData = null;
       let plannerError = null;
+      let plannerDiagnostics = null;
 
       function startOfWeek(date){
         const d = new Date(date);
@@ -426,6 +490,53 @@
         document.querySelector('[data-kpi="week1-work-orders"]').textContent = '0';
       }
 
+      function renderDiagnostics(){
+        if(!debugPanel) return;
+        if(!debugMode || !plannerDiagnostics){
+          debugPanel.dataset.visible = 'false';
+          if(debugBody) debugBody.innerHTML = '';
+          return;
+        }
+
+        const excludedPPMRows = (plannerDiagnostics.excludedRows || [])
+          .filter(row => row.exclusionReason !== 'Not a PPM category');
+
+        debugPanel.dataset.visible = 'true';
+        if(debugSummary){
+          debugSummary.textContent = [
+            `raw=${plannerDiagnostics.totalRawRowsLoaded}`,
+            `ppm=${plannerDiagnostics.ppmCategoryMatches}`,
+            `active=${plannerDiagnostics.activeCount}`,
+            `inactive=${plannerDiagnostics.inactiveCount}`,
+            `site=${plannerDiagnostics.selectedSiteSurvivors}`,
+            `w1=${plannerDiagnostics.week1Count}`,
+            `w2=${plannerDiagnostics.week2Count}`,
+            `w3=${plannerDiagnostics.week3Count}`,
+            `final=${plannerDiagnostics.finalRenderedCardCount}`,
+            `excluded=${excludedPPMRows.length}`
+          ].join(' • ');
+        }
+
+        if(!debugBody) return;
+        if(!excludedPPMRows.length){
+          debugBody.innerHTML = '<tr><td colspan="8">No excluded PPM rows for the current selection.</td></tr>';
+          return;
+        }
+
+        debugBody.innerHTML = excludedPPMRows.map((row) => `
+          <tr>
+            <td>${row.woNumber || ''}</td>
+            <td>${row.title || ''}</td>
+            <td>${row.rawCategory || ''}</td>
+            <td>${row.rawSite || ''}</td>
+            <td>${row.rawAsset || ''}</td>
+            <td>${row.rawStatus || ''}</td>
+            <td>${row.rawDueDate || ''}</td>
+            <td>${row.exclusionReason || ''}</td>
+          </tr>
+        `).join('');
+      }
+
       function renderPlanner(){
         if(plannerError){
           renderError(plannerError);
@@ -442,6 +553,10 @@
           selectedSiteKey,
           startOfWeek(new Date())
         );
+        plannerDiagnostics = window.PPMWeeklyAssetTransform.buildPPMPipelineDiagnostics(
+          plannerData.rawRows || [],
+          { siteKey: selectedSiteKey, selectedPeriodStart: startOfWeek(new Date()) }
+        );
 
         const totalWeek1 = grouped.rows.reduce((acc, row) => acc + row.weeks.week1.length, 0);
         document.querySelector('[data-kpi="total-work-orders"]').textContent = String(grouped.summary.totalWorkOrders);
@@ -455,6 +570,7 @@
           : '';
 
         plannerSurface.innerHTML = `${PPMPlannerHeader()}${rowsMarkup}${emptyMarkup}`;
+        renderDiagnostics();
       }
 
       async function loadPlannerData(){
@@ -465,6 +581,7 @@
 
           plannerData = {
             selectedWeek: source.selectedWeek,
+            rawRows: source.rawRows || [],
             activePPM
           };
 
@@ -481,6 +598,7 @@
           plannerError = `MaintainX source unavailable. ${err?.message || 'Could not load shared work order data.'}`;
           renderSiteFilter([]);
           renderPlanner();
+          renderDiagnostics();
         }
       }
 

--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -499,7 +499,7 @@
         }
 
         const excludedPPMRows = (plannerDiagnostics.excludedRows || [])
-          .filter(row => row.exclusionReason !== 'Not a PPM category');
+          .filter(row => row.exclusionReasonCode !== 'not_ppm_category');
 
         debugPanel.dataset.visible = 'true';
         if(debugSummary){


### PR DESCRIPTION
### Motivation
- Improve visibility into why work orders are excluded from the PPM planner by capturing pipeline counts and exclusion reasons. 
- Provide an in-page debug UI to assist developers in validating filtering by site and 3-week period without changing core planner logic.

### Description
- Added `buildPPMPipelineDiagnostics(rawRows, options)` which normalizes rows, classifies exclusions (not PPM, missing WO/asset, inactive status, site-filtered, out-of-range) and returns counts plus `excludedRows` with reasons. 
- Exported `buildPPMPipelineDiagnostics` from the transform API and used it in the planner flow to populate `plannerDiagnostics`. 
- Introduced a collapsible debug panel in `ppm-weekly-asset.html` (CSS, table, and summary) that is shown when the URL contains `?debug=1` and which renders excluded PPM rows (omitting general non-PPM rows). 
- Wired `renderDiagnostics()` into `renderPlanner()` and ensured diagnostics are produced from the original `rawRows` during `loadPlannerData()` so the debug panel reflects the full input pipeline.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08db18240832687e742bfb30781b7)