### PR TITLE
Fix MaintainX config reference in PPM Weekly Asset View

### DIFF
--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -621,7 +621,7 @@
 
       async function loadPlannerData(){
         try {
-          const source = await window.PPMWeeklyAssetTransform.loadMaintainXRawData(MAINTAINX_SOURCE_CONFIG);
+          const source = await window.PPMWeeklyAssetTransform.loadMaintainXRawData(window.PPMWeeklyAssetTransform.MAINTAINX_SOURCE_CONFIG);
           const normalized = window.PPMWeeklyAssetTransform.getNormalizedWorkOrders(source.rawRows);
           const activePPM = window.PPMWeeklyAssetTransform.getActivePPMWorkOrders(normalized);
 


### PR DESCRIPTION
### Motivation
- The page called `loadMaintainXRawData(MAINTAINX_SOURCE_CONFIG)` while `MAINTAINX_SOURCE_CONFIG` is defined inside the transform module and exposed via `window.PPMWeeklyAssetTransform`, which caused a runtime `MAINTAINX_SOURCE_CONFIG is not defined` error.

### Description
- Replace the direct reference with the exported config and call `window.PPMWeeklyAssetTransform.loadMaintainXRawData(window.PPMWeeklyAssetTransform.MAINTAINX_SOURCE_CONFIG)` in `ppm-weekly-asset.html` so the page uses the shared config provided by the transform module.

### Testing
- Verified the change with `rg -n "MAINTAINX_SOURCE_CONFIG" ppm-weekly-asset.html ppm-weekly-asset-transform.js` which shows the updated call, and inspected the modified lines in `ppm-weekly-asset.html`; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9f947724832682ef75e66375ee4c)