### PR TITLE
Center current week in PPM weekly planner

### DIFF
--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -585,6 +585,7 @@
 
         plannerSurface.innerHTML = `${plannerTopMarkup()}${legendMarkup()}${PPMPlannerHeader(weekKeyOrder)}${rowsMarkup}${emptyMarkup}`;
         renderMonthJump();
+        centerCurrentWeek();
       }
 
 
@@ -609,6 +610,23 @@
         });
       }
 
+
+      function scrollToWeek(weekKey, behavior = 'smooth'){
+        const index = weekKeyOrder.indexOf(weekKey);
+        if(index < 0) return;
+        const planner = document.querySelector('.planner');
+        if(!planner) return;
+        const leftEdge = 260 + (index * 120);
+        const targetLeft = Math.max(0, leftEdge - ((planner.clientWidth - 120) / 2));
+        planner.scrollTo({ left: targetLeft, behavior });
+      }
+
+      function centerCurrentWeek(){
+        if(selectedYear !== new Date().getFullYear()) return;
+        const todayKey = isoWeekKey(new Date());
+        requestAnimationFrame(() => scrollToWeek(todayKey, 'auto'));
+      }
+
       function renderMonthJump(){
         const monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
         const monthMap = buildMonthMap(weekKeyOrder);
@@ -622,8 +640,7 @@
           button.addEventListener('click', () => {
             const index = weekKeyOrder.indexOf(button.dataset.weekKey);
             if(index < 0) return;
-            const planner = document.querySelector('.planner');
-            planner.scrollTo({ left: 260 + (index * 120), behavior: 'smooth' });
+            scrollToWeek(weekKeyOrder[index]);
           });
         });
       }


### PR DESCRIPTION
### Motivation
- Users should land on the current ISO week when opening the PPM weekly planner so “this week” is visible and centered in the viewport. 
- Consolidate and standardize horizontal scrolling logic for month-jump and programmatic week navigation.

### Description
- Added a `scrollToWeek(weekKey, behavior)` helper in `ppm-weekly-asset.html` that computes a centered horizontal offset and calls `scrollTo` on the planner container. 
- Added `centerCurrentWeek()` which resolves the current ISO week with `isoWeekKey(new Date())` and calls `scrollToWeek` (invoked only when `selectedYear` equals the current year). 
- Call `centerCurrentWeek()` after grid render in `renderPlanner()` so the planner auto-centers the current week on initial render. 
- Updated month-jump button handling to reuse `scrollToWeek()` for consistent scrolling behavior.

### Testing
- No automated tests were run because there is no test suite configured for this static HTML page in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca9b4298c8326834c90dc89b4d173)