### PR TITLE
Fix PPM weekly asset source to use full raw work orders

### DIFF
--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -6,7 +6,7 @@
   const RAW_WORK_ORDERS_CSV_URL =
     'https://docs.google.com/spreadsheets/d/1bVi12enMnCmUVmzR_add6e38qFggHwVGwI1PWrIggl4/gviz/tq?tqx=out:csv&sheet=MX_Raw_WorkOrders';
   const MAINTAINX_SOURCE_CONFIG = Object.freeze({
-    sourceMode: 'selected_week'
+    sourceMode: 'raw_work_orders'
   });
 
   const ACTIVE_STATUS_ALLOWLIST = [


### PR DESCRIPTION
### Motivation
- The weekly asset view could miss assets because it was sourcing a single `selected_week` sheet instead of the complete `MX_Raw_WorkOrders` dataset.

### Description
- Change `MAINTAINX_SOURCE_CONFIG.sourceMode` from `'selected_week'` to `'raw_work_orders'` in `ppm-weekly-asset-transform.js` so the planner is built from the full raw work orders feed.

### Testing
- Loaded the transform with `node -e "require('./ppm-weekly-asset-transform.js'); console.log('ok')"` which printed `ok`, indicating the module initializes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcaaf1262c8326a578abb57f19800a)