### PR TITLE
Highlight current week column in PPM weekly asset view

### DIFF
--- a/ppm-weekly-asset.html
+++ b/ppm-weekly-asset.html
@@ -268,6 +268,14 @@
     .week-cell--orange { background:color-mix(in srgb,var(--card-orange) 42%,var(--paper)); }
     .week-cell--blue { background:color-mix(in srgb,var(--card-blue) 42%,var(--paper)); }
     .week-cell--green { background:color-mix(in srgb,var(--card-green) 42%,var(--paper)); }
+    .current-week-col {
+      background:color-mix(in srgb,var(--als-blue) 10%,var(--paper));
+      box-shadow:inset 0 0 0 2px color-mix(in srgb,var(--als-blue) 45%,transparent);
+    }
+    .planner-header .current-week-col {
+      font-weight:900;
+      color:var(--als-blue);
+    }
 
     .wo-card {
       border:1px solid color-mix(in srgb,var(--als-blue) 28%,var(--grid));
@@ -460,7 +468,12 @@
       }
 
       function PPMPlannerHeader(weekKeys){
-        const weekColumns = weekKeys.map((weekKey) => `<div class="planner-cell" role="columnheader">${weekKey.replace('-', ' ')}</div>`).join('');
+        const currentWeekKey = getCurrentWeekKeyForSelectedYear();
+        const weekColumns = weekKeys.map((weekKey) => {
+          const isCurrent = currentWeekKey === weekKey;
+          const classAttr = isCurrent ? 'planner-cell current-week-col' : 'planner-cell';
+          return `<div class="${classAttr}" role="columnheader">${weekKey.replace('-', ' ')}</div>`;
+        }).join('');
         return `
           <div class="planner-header" role="row">
             <div class="planner-cell" role="columnheader">Asset ↕</div>
@@ -497,10 +510,14 @@
       }
 
       function PPMAssetRow(row, weekKeys){
+        const currentWeekKey = getCurrentWeekKeyForSelectedYear();
         const weekCells = weekKeys.map((weekKey) => {
           const weekOrders = row.weeks[weekKey] || [];
           const statusClass = weekCellStatusClass(weekOrders);
-          const classAttr = statusClass ? `planner-cell week-cell ${statusClass}` : 'planner-cell week-cell';
+          const currentClass = currentWeekKey === weekKey ? ' current-week-col' : '';
+          const classAttr = statusClass
+            ? `planner-cell week-cell ${statusClass}${currentClass}`
+            : `planner-cell week-cell${currentClass}`;
           return `<div class="${classAttr}" role="gridcell">${renderWeekCards(weekOrders)}</div>`;
         }).join('');
         return `
@@ -641,6 +658,12 @@
       }
 
 
+      function getCurrentWeekKeyForSelectedYear(){
+        const today = new Date();
+        if(selectedYear !== today.getFullYear()) return null;
+        return isoWeekKey(today);
+      }
+
       function scrollToWeek(weekKey, behavior = 'smooth'){
         const index = weekKeyOrder.indexOf(weekKey);
         if(index < 0) return;
@@ -652,8 +675,8 @@
       }
 
       function centerCurrentWeek(){
-        if(selectedYear !== new Date().getFullYear()) return;
-        const todayKey = isoWeekKey(new Date());
+        const todayKey = getCurrentWeekKeyForSelectedYear();
+        if(!todayKey) return;
         requestAnimationFrame(() => scrollToWeek(todayKey, 'auto'));
       }
 


### PR DESCRIPTION
### Motivation
- Improve usability of the PPM weekly asset matrix by making the current calendar week visually distinct so users can quickly orient themselves in the planner.
- Ensure header and per-asset cells are consistently highlighted and that centering behavior relies on the same current-week calculation.

### Description
- Add `.current-week-col` CSS rules in `ppm-weekly-asset.html` to apply a subtle blue tint and inset outline for the active week column.
- Update `PPMPlannerHeader` to compute the current week key and apply `current-week-col` to the matching header cell when rendering week columns.
- Update `PPMAssetRow` to apply `current-week-col` to the matching week grid cell for each asset so the highlight is vertical across the matrix.
- Add `getCurrentWeekKeyForSelectedYear()` helper and reuse it from `PPMPlannerHeader`, `PPMAssetRow`, and `centerCurrentWeek()` so the highlight and auto-centering use a single current-week resolution (only active when viewing the current year).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcab2159e483268f78ca0e1c9c7620)