### PR TITLE
Remove 'done' from INACTIVE_STATUS_BLOCKLIST to treat it as active

### DIFF
--- a/ppm-weekly-asset-transform.js
+++ b/ppm-weekly-asset-transform.js
@@ -30,7 +30,6 @@
     'inactive',
     'closed',
     'complete',
-    'done',
     'rejected'
   ];
 


### PR DESCRIPTION
### Motivation
- Prevent records with status `done` from being classified as inactive so they remain eligible for active processing and weekly PPM transformations.

### Description
- Remove the `'done'` entry from the `INACTIVE_STATUS_BLOCKLIST` constant in `ppm-weekly-asset-transform.js` so `done` is no longer considered an inactive status.

### Testing
- Ran the existing automated test suite and linters against the change and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0191d9a960832692585746954bb337)