### PR TITLE
Include Colin in Eng Schedule Jim/Ciaren entry

### DIFF
--- a/facilities.html
+++ b/facilities.html
@@ -1966,7 +1966,7 @@ function chipStyle(label, slugOverride){ const slug=slugOverride||slugify(label)
 // --- Name aliases / shortening ---
 const NAME_ALIASES = new Map([
   ['callum keith engineering team', 'Callum'],
-  ['east kilbride engineering team', 'Jim and Ciaren'],
+  ['east kilbride engineering team', 'Jim and Ciaren and Colin'],
   // add more here...
 ]);
 

--- a/index.html
+++ b/index.html
@@ -3526,7 +3526,7 @@ function chipStyle(label, slugOverride){ const slug=slugOverride||slugify(label)
 // --- Name aliases / shortening ---
 const NAME_ALIASES = new Map([
   ['callum keith engineering team', 'Callum'],
-  ['east kilbride engineering team', 'Jim and Ciaren'],
+  ['east kilbride engineering team', 'Jim and Ciaren and Colin'],
   // add more here...
 ]);
 
@@ -3809,7 +3809,7 @@ function applyHistoricalStatus(rows, weekEnd){
 
 /* --- Eng Schedule integration --- */
 const PLAN_DEFAULT_DAYS = ['Monday','Tuesday','Wednesday','Thursday','Friday','Non-Production Day'];
-const PLAN_DEFAULT_PEOPLE = ['Callum','Graeme','Cameron','Jim/Ciaren'];
+const PLAN_DEFAULT_PEOPLE = ['Callum','Graeme','Cameron','Jim/Ciaren/Colin'];
 const PLAN_FOCUS_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 function normalizePlanList(value){
@@ -3997,13 +3997,13 @@ const PLAN_PERSON_ALIAS_TARGETS = new Map([
   ['shaun','MM'],
   ['sean','MM'],
   ['cameron','Cameron'],
-  ['jim','Jim/Ciaren'],
-  ['ciaren','Jim/Ciaren'],
-  ['jimciaren','Jim/Ciaren'],
-  ['jim and ciaren','Jim/Ciaren'],
-  ['jim & ciaren','Jim/Ciaren'],
-  ['jim/ciaren','Jim/Ciaren'],
-  ['jim and cieren','Jim/Ciaren'],
+  ['jim','Jim/Ciaren/Colin'],
+  ['ciaren','Jim/Ciaren/Colin'],
+  ['jimciaren','Jim/Ciaren/Colin'],
+  ['jim and ciaren','Jim/Ciaren/Colin'],
+  ['jim & ciaren','Jim/Ciaren/Colin'],
+  ['jim/ciaren','Jim/Ciaren/Colin'],
+  ['jim and cieren','Jim/Ciaren/Colin'],
 ]);
 
 let PLAN_NEXT_WEEK_RAW = null;


### PR DESCRIPTION
### Motivation
- Ensure the Eng Schedule UI and team display include Colin by updating the Jim/Ciaren label and its aliases so the schedule and team names are accurate.

### Description
- Modified `index.html` and `facilities.html` to change the `NAME_ALIASES` east kilbride entry to include Colin and to replace `Jim/Ciaren` with `Jim/Ciaren/Colin` in `PLAN_DEFAULT_PEOPLE` and `PLAN_PERSON_ALIAS_TARGETS` so all mappings and defaults resolve to the new combined label.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07290c2a048326be9c70ed05a44081)