### PR TITLE
Add Caleb to Eng Schedule default engineer list

### DIFF
--- a/index.html
+++ b/index.html
@@ -3809,7 +3809,7 @@ function applyHistoricalStatus(rows, weekEnd){
 
 /* --- Eng Schedule integration --- */
 const PLAN_DEFAULT_DAYS = ['Monday','Tuesday','Wednesday','Thursday','Friday','Non-Production Day'];
-const PLAN_DEFAULT_PEOPLE = ['Callum','Graeme','Cameron','Jim/Ciaren'];
+const PLAN_DEFAULT_PEOPLE = ['Callum','Graeme','Cameron','Jim/Ciaren','Caleb'];
 const PLAN_FOCUS_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 function normalizePlanList(value){


### PR DESCRIPTION
### Motivation
- Ensure Caleb appears as a selectable engineer in the Eng Schedule UI when no custom people list is supplied.

### Description
- Added `Caleb` to the `PLAN_DEFAULT_PEOPLE` array in `index.html` so the default engineer list now includes Caleb.

### Testing
- No automated tests were run for this static data-list update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0728cb03248326823354d420aa5723)